### PR TITLE
Update/log error

### DIFF
--- a/jsjaws.py
+++ b/jsjaws.py
@@ -129,6 +129,7 @@ class JsJaws(ServiceBase):
         allow_download_from_internet = self.config.get("allow_download_from_internet", False)
         tool_timeout = request.get_param("tool_timeout")
         browser_selected = request.get_param("browser")
+        log_errors = request.get_param("log_errors")
         wscript_only = request.get_param("wscript_only")
         throw_http_exc = request.get_param("throw_http_exc")
         extract_function_calls = request.get_param("extract_function_calls")
@@ -208,6 +209,11 @@ class JsJaws(ServiceBase):
         # for the sample to be run in WScript only
         if wscript_only:
             malware_jail_args.extend(["-c", self.wscript_only_config])
+
+        # By default, we don't want to replace exception catching in a script with a log of the exception,
+        # but it is useful for debugging
+        if log_errors:
+            malware_jail_args.append("--logerrors")
 
         jsxray_args = ["node", self.path_to_jsxray]
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -83,6 +83,11 @@ submission_params:
     type: bool
     value: false
 
+  - default: false
+    name: log_errors
+    type: bool
+    value: false
+
 heuristics:
   - heur_id: 1
     name: Network Traffic Detected

--- a/tests/test_jsjaws.py
+++ b/tests/test_jsjaws.py
@@ -283,6 +283,7 @@ class TestJsJaws:
             "static_signatures": True,
             "no_shell_error": False,
             "display_iocs": False,
+            "log_errors": False,
         }
         jsjaws_class_instance._task = task
         service_request = ServiceRequest(task)
@@ -355,6 +356,7 @@ class TestJsJaws:
         service_request.task.service_config["no_shell_error"] = True
         service_request.task.service_config["static_signatures"] = False
         service_request.task.service_config["add_supplementary"] = True
+        service_request.task.service_config["log_errors"] = True
         mocker.patch("jsjaws.run", side_effect=TimeoutExpired("blah", 1))
         jsjaws_class_instance.execute(service_request)
 

--- a/tools/env/eval.js
+++ b/tools/env/eval.js
@@ -1,11 +1,11 @@
-util_log("Preparing sandbox to intercept eval() calls.");
-eval = function() {
+util_log("Preparing sandbox to intercept eval calls.");
+eval = function () {
     let _eval_calls = [];
     _data["eval_calls"] = _eval_calls;
     let _orig_eval;
     if (typeof _orig_eval === 'undefined')
         _orig_eval = eval;
-    let _ = function(s) {
+    let _ = function (s) {
         let _t = {};
         _t["orig"] = s;
         let ns;
@@ -23,24 +23,15 @@ eval = function() {
         //ns1 = ns;
         _t["safe_funcs"] = ns;
         _eval_calls[_eval_calls.length] = _t;
-        var _isStrict = (function() {
+        var _isStrict = (function () {
             return !this;
         })();
 
-        ns1 = ns1.replace(/\/\*@cc_on/gi, "");
-        ns1 = ns1.replace(/@\*\//gi, "");
-        ns1 = ns1.replace(/@if.*/gi, "");
-        ns1 = ns1.replace(/@else.*/gi, "");
-        ns1 = ns1.replace(/@elif.*/gi, "");
-        ns1 = ns1.replace(/@end.*/gi, "");
-
-        ns1 = ns1.replace(/\} *var\b/g, "}; var");
-
         //util_log("Strict mode:", _isStrict);
         if (ns1 !== "") {
-            util_log("Calling eval('" + _truncateOutput(ns1) +"')");
+            util_log("Calling eval('" + _truncateOutput(ns1) + "')");
         }
         return _orig_eval(ns1);
     }
-    return function eval(s) { /* [native code ] */ return _(s)}
+    return function eval(s) { /* [native code ] */ return _(s) }
 }();

--- a/tools/jailme.js
+++ b/tools/jailme.js
@@ -297,7 +297,7 @@ function run_in_ctx(files, log_catch = false) {
             if (log_catch) {
                 // Write two files, one with the unescaped file contents and another with the escaped file contents
                 // Time for the unescaped file contents
-                fc = fc.replace(/\bcatch\b\s*\((.*?)\)\s*{/g, 'catch($1) { util_log(_sc + _inspect($1));');
+                fc = fc.replace(/\bcatch\b\s*\((.*?)\)\s*{(?!\s*util_log\()/g, 'catch($1) { util_log(_sc + _inspect($1));');
                 let fname = files[i].replace(/\//g, "_");
                 let fname2 = config.save_files + "deobfuscated" + fname;
                 util.log("Saving: " + fname2);

--- a/tools/jailme.js
+++ b/tools/jailme.js
@@ -32,6 +32,7 @@ if (argv.h || argv.help) {
     util.log("\t--t404   ... on download return always HTTP/404 and throw exception");
     util.log("\t--extractfns   ... extract Function calls as files or 'payloads'");
     util.log("\t--extractevals   ... extract Eval calls as files or 'payloads'");
+    util.log("\t--logerrors   ... log errors that are caught");
     util.log("\tmalware  ... js with the malware code");
     util.log("If no arguments are specified the default values are taken from config.json");
     _exit = true;
@@ -89,6 +90,10 @@ if (argv.extractevals) {
     config.extractevals = true;
     util.log("Extract Eval Calls to output directory");
 }
+if (argv.logerrors) {
+    config.logerrors = true;
+    util.log("Log errors that are caught");
+}
 if (typeof argv.o === 'string')
     config.context_dump_after = argv.o
 util.log("Output file for sandbox dump: " + config.context_dump_after);
@@ -113,10 +118,10 @@ util.log("Output directory for generated files: " + config.save_files);
 //    process.exit();
 //});
 
-var _proxy = function(o, verbose = false, what = undefined) {
+var _proxy = function (o, verbose = false, what = undefined) {
     var util_log = mylog;
     ret = new Proxy(o, {
-        get: function(target, name, receiver) {
+        get: function (target, name, receiver) {
             if (verbose) {
                 if (typeof name === 'symbol')
                     vname = name.toString();
@@ -154,7 +159,7 @@ var _proxy = function(o, verbose = false, what = undefined) {
 
             return ret;
         },
-        set: function(target, name, value) {
+        set: function (target, name, value) {
             if (verbose) {
                 if (typeof name === 'symbol')
                     vname = name.toString();
@@ -171,13 +176,13 @@ var _proxy = function(o, verbose = false, what = undefined) {
             }
             return Reflect.set(target, name, value);
         },
-        construct: function(target, args, newTarget) {
+        construct: function (target, args, newTarget) {
             if (verbose) {
                 util_log("Proxy.construct: " + target + "(" + _truncateOutput(args.join(", "), 50) + ")");
             }
             return _proxy(Reflect.construct(target, args, newTarget));
         },
-        apply: function(target, that, args) {
+        apply: function (target, that, args) {
             if (verbose) {
                 util_log("Proxy.apply: " + target + "(" + _truncateOutput(args.join(", "), 50) + ")");
             }
@@ -281,17 +286,15 @@ let i;
 // The file contents of the sample
 let fc;
 
-function run_in_ctx(files, malware = true /*no_log = false, catch_catch = false*/) {
-    var no_log = !malware;
-    var catch_catch = malware;
+function run_in_ctx(files, log_catch = false) {
+    var log_catch = log_catch;
     try {
         for (i = 0; i < files.length; i++) {
-            util.log(" => Executing: " + files[i] + ((no_log) ? " quitely" : " verbosely") + ((catch_catch) ? ", reporting silent catches" : ""));
+            util.log(" => Executing: " + files[i] + ((log_catch) ? ", reporting silent catches" : ""));
             fc = fs.readFileSync(files[i], 'utf8');
-            _dont_log = no_log;
             sandbox._script_name = files[i];
             // log every exception caught by the script itself
-            if (catch_catch) {
+            if (log_catch) {
                 // Write two files, one with the unescaped file contents and another with the escaped file contents
                 // Time for the unescaped file contents
                 fc = fc.replace(/\bcatch\b\s*\((.*?)\)\s*{/g, 'catch($1) { util_log(_sc + _inspect($1));');
@@ -326,20 +329,18 @@ function run_in_ctx(files, malware = true /*no_log = false, catch_catch = false*
                 // util.log("Saving: " + fname2);
                 // fs.writeFileSync(fname2, x);
             }
-            if (malware) {
-                fc = fc.replace(/\/\*@cc_on/gi, "");
-                fc = fc.replace(/@\*\//gi, "");
-                fc = fc.replace(/@if.*/gi, "");
-                fc = fc.replace(/@else.*/gi, "");
-                fc = fc.replace(/@elif.*/gi, "");
-                fc = fc.replace(/@end.*/gi, "");
+            fc = fc.replace(/\/\*@cc_on/gi, "");
+            fc = fc.replace(/@\*\//gi, "");
+            fc = fc.replace(/@if.*/gi, "");
+            fc = fc.replace(/@else.*/gi, "");
+            fc = fc.replace(/@elif.*/gi, "");
+            fc = fc.replace(/@end.*/gi, "");
 
-                fc = fc.replace(/\} *var\b/g, "}; var");
+            fc = fc.replace(/\} *var\b/g, "}; var");
 
-                if ("WScript" in sandbox) {
-                    sandbox.WScript.scriptfullname = files[i];
-                    sandbox.WScript.arguments = [files[i], "xyz"];
-                }
+            if ("WScript" in sandbox) {
+                sandbox.WScript.scriptfullname = files[i];
+                sandbox.WScript.arguments = [files[i], "xyz"];
             }
             vm.runInContext(fc, ctx, {
                 filename: files[i],
@@ -376,12 +377,12 @@ sandbox.require = undefined;
 
 // Run the malware
 util.log("==> Executing malware file(s). =========================================");
-process.exitCode = run_in_ctx(config.malware_files, true) ? 0 : 1;
+process.exitCode = run_in_ctx(config.malware_files, log_catch = config.logerrors) ? 0 : 1;
 sandbox._config = config;
 sandbox._arguments = process.argv.slice(2).join(" ");
 exiting = false;
 
-var dump_sandbox = function() {
+var dump_sandbox = function () {
     var s2 = {};
     var ctx2 = vm.createContext(s2);
     var i, fc;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59843993/182423089-2298f53a-347e-422a-8791-de2140735955.png)

If the JavaScript contained a try-catch for an exception, MalwareJail would use a regex that would add a log within that catch statement. This would create recursive behaviour in Assemblyline. With this PR, by tweaking the regex, this should be avoided, as well as providing this functionality as a configurable option in the submission.