### PR TITLE
Update/css handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 html5lib
+tinycss2

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -129,6 +129,12 @@ heuristics:
     filetype: '*'
     description: Automatic redirection to another resource
 
+  - heur_id: 7
+    name: Suspicious CSS Usage
+    score: 0
+    filetype: '*'
+    description: Suspicious declarations were detected in HTML stylesheets
+
 docker_config:
   allow_internet_access: true
   image: ${REGISTRY}cccs/assemblyline-service-jsjaws:$SERVICE_TAG

--- a/tests/results/740440a64bba44761eef87e0f8755e9df4cb5075c8a7caa938f1571c304edb05/result.json
+++ b/tests/results/740440a64bba44761eef87e0f8755e9df4cb5075c8a7caa938f1571c304edb05/result.json
@@ -63,7 +63,7 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<embed>",
+        "name": "Element[15]<embed>",
         "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
       }
     ],

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
@@ -5,6 +5,24 @@
     "sections": [
       {
         "auto_collapse": false,
+        "body": "Suspicious declarations were detected in HTML stylesheets",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 7,
+          "score": 0,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "Suspicious CSS Usage",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
         "body": null,
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -63,7 +81,11 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<embed>",
+        "name": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7",
+        "sha256": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7"
+      },
+      {
+        "name": "Element[15]<embed>",
         "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
       }
     ],
@@ -71,6 +93,10 @@
       {
         "name": "temp_javascript.js",
         "sha256": "66c02bb2c5f562b07c93e75a820da97de351f8e012b6033c48cec05e57589677"
+      },
+      {
+        "name": "temp_css.css",
+        "sha256": "9ae702f0ebdbe99d96c0270cfca6e0cc5fb69de7f6544a246e2a58fe7f478ce1"
       }
     ]
   },
@@ -89,6 +115,11 @@
         "signatures": [
           "append_and_click"
         ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 7,
+        "signatures": []
       }
     ],
     "tags": {},

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
@@ -81,8 +81,8 @@
   "files": {
     "extracted": [
       {
-        "name": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7",
-        "sha256": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7"
+        "name": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa",
+        "sha256": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa"
       },
       {
         "name": "Element[15]<embed>",

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -5,6 +5,24 @@
     "sections": [
       {
         "auto_collapse": false,
+        "body": "Suspicious declarations were detected in HTML stylesheets",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 7,
+          "score": 0,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "Suspicious CSS Usage",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
         "body": null,
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -63,7 +81,11 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<embed>",
+        "name": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7",
+        "sha256": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7"
+      },
+      {
+        "name": "Element[15]<embed>",
         "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
       }
     ],
@@ -71,6 +93,10 @@
       {
         "name": "temp_javascript.js",
         "sha256": "66c02bb2c5f562b07c93e75a820da97de351f8e012b6033c48cec05e57589677"
+      },
+      {
+        "name": "temp_css.css",
+        "sha256": "9ae702f0ebdbe99d96c0270cfca6e0cc5fb69de7f6544a246e2a58fe7f478ce1"
       }
     ]
   },
@@ -89,6 +115,11 @@
         "signatures": [
           "append_and_click"
         ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 7,
+        "signatures": []
       }
     ],
     "tags": {},

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -81,8 +81,8 @@
   "files": {
     "extracted": [
       {
-        "name": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7",
-        "sha256": "d87b0e79842cee502bbb1eb2161596fb7ca21db80dc58532dbd0a7e02828abb7"
+        "name": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa",
+        "sha256": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa"
       },
       {
         "name": "Element[15]<embed>",

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 531,
     "sections": [
       {
         "auto_collapse": false,
@@ -57,6 +57,76 @@
         "tags": {},
         "title_text": "Signature: PrepareNetworkRequest",
         "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript writes data to disk\n\t\tsaveAs([object Blob], attachment.zip)\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "save_to_file": 10
+          },
+          "signatures": {
+            "save_to_file": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: SaveToFile",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript writes archive file to disk\n\t\tsaveAs([object Blob], attachment.zip)\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 500,
+          "score_map": {
+            "writes_archive": 500
+          },
+          "signatures": {
+            "writes_archive": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: WritesArchive",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"attachment.zip\"}]",
+        "body_format": "TABLE",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 2,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {
+          "network": {
+            "dynamic": {
+              "domain": [
+                "attachment.zip"
+              ]
+            }
+          }
+        },
+        "title_text": "MalwareJail extracted the following IOCs",
+        "zeroize_on_tag_safe": false
       }
     ]
   },
@@ -73,6 +143,11 @@
     "heuristics": [
       {
         "attack_ids": [],
+        "heur_id": 2,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
         "heur_id": 3,
         "signatures": [
           "suspicious_char_codes"
@@ -84,9 +159,31 @@
         "signatures": [
           "prepare_network_request"
         ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "save_to_file"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "writes_archive"
+        ]
       }
     ],
-    "tags": {},
+    "tags": {
+      "network.dynamic.domain": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "attachment.zip"
+        }
+      ]
+    },
     "temp_submission_data": {}
   }
 }

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -131,7 +131,12 @@
     ]
   },
   "files": {
-    "extracted": [],
+    "extracted": [
+      {
+        "name": "attachment.zip",
+        "sha256": "6e997245b12dc1a3cdaf9620f129810908990458da866f8b70a6bdb8a279fd43"
+      }
+    ],
     "supplementary": [
       {
         "name": "temp_javascript.js",

--- a/tools/env/browser.js
+++ b/tools/env/browser.js
@@ -352,7 +352,12 @@ Document.toString = Document.toJSON = () => { return "Document" }
 document = _proxy(new Document());
 
 // create a stylesheet element with the contents from the extracted CSS in the HTML
-stylesheet_contents = fs.readFileSync(_stylesheet, "utf8");
+try {
+    stylesheet_contents = fs.readFileSync(_stylesheet, "utf8");
+}
+catch(err) {
+    stylesheet_contents = "";
+}
 document.createstylesheet(stylesheet_contents)
 
 document.toString = () => { return "document" }

--- a/tools/env/browser.js
+++ b/tools/env/browser.js
@@ -6,6 +6,7 @@ util_log("Preparing sandbox to emulate Browser environment (default = IE11).");
 _browser_documents = [];
 
 const { atob, btoa } = require("abab");
+const fs = require("fs");
 
 location = _proxy({
     _name: "location",
@@ -143,7 +144,6 @@ window = _proxy(new function () {
                 this._location.href = n;
             }
         })
-    this.top = function () { }
     this.self = function () {
         this.location = function () {
             util_log("get location" + arguments)
@@ -161,6 +161,8 @@ window = _proxy(new function () {
 window.toString = () => { return "window" }
 window.XMLHttpRequest = true;
 
+// top is actually the sandbox environment itself. Mind blown.
+top = this;
 
 for (let k in _browser_api) {
     if (_browser_api.hasOwnProperty(k))
@@ -251,7 +253,9 @@ Document = _proxy(function () {
     };
     this.createstylesheet = function (n) {
         util_log(this._name + ".createStyleSheet(" + n + ")");
-        return this.createelement("style");
+        style_element = this.createelement("style");
+        style_element._attributes["styleSheet"]["cssText"] = n;
+        return style_element;
     };
     this.write = function (c) {
         util_log(this._name + ".write(content) " + c.length + " bytes");
@@ -323,8 +327,14 @@ Document = _proxy(function () {
     this.readyState = function (n) {
         util_log("readyState(" + n + ")");
     }
-    this.addEventListener = function (n) {
-        util_log("addEventListener(" + n + ")");
+    this.addEventListener = function () {
+        util_log(this._name + ".addEventListener(" + Array.prototype.slice.call(arguments, 0) + ")")
+        for (i = 0; i < arguments.length; i++) {
+            let e = arguments[i];
+            if (typeof(e) === "function") {
+                e();
+            }
+        }
     }
     this.attachEvent = function (n) {
         util_log("attachEvent(" + n + ")");
@@ -340,6 +350,11 @@ Document.prototype.constructor = Document;
 Document.toString = Document.toJSON = () => { return "Document" }
 
 document = _proxy(new Document());
+
+// create a stylesheet element with the contents from the extracted CSS in the HTML
+stylesheet_contents = fs.readFileSync(_stylesheet, "utf8");
+document.createstylesheet(stylesheet_contents)
+
 document.toString = () => { return "document" }
 window.document = document;
 window.URL = URL;

--- a/tools/env/wscript.js
+++ b/tools/env/wscript.js
@@ -45,9 +45,12 @@ gapi = function () {
 
 // /*
 File = function (sources, filename, options = undefined) {
+    util_log("File(" + sources + ", " + filename + ", " + options + ")")
     if (options)
-        return new Blob(sources, options);
-    return new Blob(sources);
+        blob = new Blob(sources, options);
+    blob = new Blob(sources);
+    saveAs(blob, filename)
+    return blob;
 }
 // */
 
@@ -1506,7 +1509,6 @@ ADODB_Stream = function () {
         var encoding = 'binary';
         //util_log(this._name + ".LoadFromFile(" + a + ")");
         if (this.type == 2 && typeof this.charset !== 'undefined') {
-            //util_log("here");
             this.content = _iconv.decode(Buffer.from(_wscript_saved_files[a]), this.charset);
             encoding = this.charset;
         } else {
@@ -1938,7 +1940,7 @@ MSXML2_XMLHTTP.toString = () => {
     return "MSXML2_XMLHTTP"
 }
 
-Style = _proxy(function () {
+Style = _proxy(function (css_text = "") {
     this._id = _object_id++;
     this._name = "Style[" + this._id + "]";
     this.elementName = "style";
@@ -1947,8 +1949,8 @@ Style = _proxy(function () {
         "left": 0,
         "top": 0,
         "position": "",
-        "stylesheet": {
-            cssText: ""
+        "styleSheet": {
+            cssText: css_text
         }
     };
     this.toString = this.tostring = () => {

--- a/tools/env/wscript.js
+++ b/tools/env/wscript.js
@@ -43,7 +43,6 @@ gapi = function () {
     this.load = function () { };
 }
 
-// /*
 File = function (sources, filename, options = undefined) {
     util_log("File(" + sources + ", " + filename + ", " + options + ")")
     if (options)
@@ -52,24 +51,6 @@ File = function (sources, filename, options = undefined) {
     saveAs(blob, filename)
     return blob;
 }
-// */
-
-/*
-File = function (sources, filename, options = undefined) {
-    if (options)
-        this._blob = new Blob(sources, options);
-    else
-        this._blob = new Blob(sources)
-    this._filename = filename;
-    this.constructor.name = "File";
-    this.toString = function () {
-        return "File[" + this._filename + "]";
-    }
-    this.arrayBuffer = function () {
-        return this._blob.arrayBuffer();
-    }
-};
-*/
 
 URL.createObjectURL = async function (content) {
     util_log("URL.createObjectURL(" + content + ")")
@@ -81,9 +62,14 @@ URL.createObjectURL = async function (content) {
     return url_blob;
 }
 
-URL.revokeObjectURL = function (src) {
+URL.revokeObjectURL = async function (src) {
     util_log("URL.revokeObjectURL(" + src + ")");
-    _wscript_saved_files["url_blob"] = src.srcObject;
+    if (src.constructor.name == "Promise") {
+        util_log("Revoking ObjectURL Promise");
+    }
+    else {
+        _wscript_saved_files["url_blob"] = src.srcObject;
+    }
 }
 
 let Base64 = {

--- a/tools/jailme.cjs
+++ b/tools/jailme.cjs
@@ -28,6 +28,7 @@ if (argv.h || argv.help) {
     console.log("\t-s odir  ... output directory for generated files (malware payload)");
     console.log("\t-b id    ... browser type, use -b list for possible values");
     console.log("\t-t msecs ... number of miliseconds before terminating execution, default 1 minute");
+    console.log("\t--stylesheet stylesheet  ... custom CSS stylesheet");
     console.log("\t--trace  ... print stack trace with every log line");
     console.log("\t--down   ... allow downloading malware payloads from remote servers");
     console.log("\t--h404   ... on download return always HTTP/404");
@@ -102,6 +103,11 @@ console.log("Output file for sandbox dump: " + config.context_dump_after);
 if (typeof argv.s === 'string')
     config.save_files = argv.s
 console.log("Output directory for generated files: " + config.save_files);
+
+if (argv.stylesheet) {
+    config.stylesheet = argv.stylesheet;
+    console.log("Use a custom stylesheet: " + config.stylesheet);
+}
 //if (process.platform === "win32") {
 //    var rl = require("readline").createInterface({
 //        input: process.stdin,
@@ -283,6 +289,8 @@ sandbox._browser_api = {
     'JSON': JSON,
     'Function': Function
 }
+
+sandbox._stylesheet = config.stylesheet;
 
 fs = require('fs');
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";

--- a/tools/tinycss2_helper.py
+++ b/tools/tinycss2_helper.py
@@ -1,3 +1,7 @@
+"""
+This helper class is for facilitating the adoption of the tinycss2 library
+"""
+
 import functools
 
 from tinycss2.ast import (
@@ -16,8 +20,38 @@ SKIP_WHITESPACE = False
 
 
 def parse_declaration_list(tokens, skip_comments=False, skip_whitespace=False):
-    """
-    This method is the entry point to parsing the declaration list
+    """Parse a :diagram:`declaration list` (which may also contain at-rules).
+
+    This is used e.g. for the tokenized values of :attr:`~tinycss2.ast.QualifiedRule.content`
+    of a style rule or ``@page`` rule,
+    or for the ``style`` attribute of an HTML element.
+
+    In contexts that don’t expect any at-rule,
+    all :class:`~tinycss2.ast.AtRule` objects
+    should simply be rejected as invalid.
+
+    :type tokens: :term:`iterator`
+    :param tokens: An iterator yielding :term:`component values`.
+    :type skip_comments: :obj:`bool`
+    :param skip_comments:
+        Ignore CSS comments at the top-level of the list.
+        If the input is a string, ignore all comments.
+    :type skip_whitespace: :obj:`bool`
+    :param skip_whitespace:
+        Ignore whitespace at the top-level of the list.
+        Whitespace is still preserved
+        in the :attr:`~tinycss2.ast.Declaration.value` of declarations
+        and the :attr:`~tinycss2.ast.AtRule.prelude`
+        and :attr:`~tinycss2.ast.AtRule.content` of at-rules.
+    :returns:
+        A list of
+        :class:`~tinycss2.ast.Declaration`,
+        :class:`~tinycss2.ast.AtRule`,
+        :class:`~tinycss2.ast.Comment` (if ``skip_comments`` is false),
+        :class:`~tinycss2.ast.WhitespaceToken`
+        (if ``skip_whitespace`` is false),
+        and :class:`~tinycss2.ast.ParseError` objects
+
     """
     global SKIP_WHITESPACE
     global SKIP_COMMENTS
@@ -78,20 +112,12 @@ def _parse_declaration(first_token, tokens):
     name = first_token
     if name.type != 'ident':
         return
-        # return ParseError(name.source_line, name.source_column, 'invalid',
-        #                   'Expected <ident> for declaration name, got %s.'
-        #                   % name.type)
 
     colon = _next_significant(tokens)
     if colon is None:
         return
-        # return ParseError(name.source_line, name.source_column, 'invalid',
-        #                   "Expected ':' after declaration name, got EOF")
     elif colon != ':':
         return
-        # return ParseError(colon.source_line, colon.source_column, 'invalid',
-        #                   "Expected ':' after declaration name, got %s."
-        #                   % colon.type)
 
     value = []
     state = 'value'
@@ -127,9 +153,18 @@ def _next_significant(tokens):
 
 
 def significant_tokens(tokens):
+    """
+    This method returns the significant tokens (neither whitespace or comment)
+
+    :type tokens: :term:`iterator`
+    :param tokens: An iterator yielding :term:`component values`.
+    :returns: The significant tokens.
+    """
     return [token for token in tokens if token.type not in ('whitespace', 'comment')]
 
 
+
+# The following was pulled from the tinycss2 testing suite to assist with JSON conversions
 def _generic(func):
     implementations = func()
 

--- a/tools/tinycss2_helper.py
+++ b/tools/tinycss2_helper.py
@@ -1,0 +1,195 @@
+import functools
+
+from tinycss2.ast import (
+    AtKeywordToken, AtRule, Comment, CurlyBracketsBlock, Declaration,
+    DimensionToken, FunctionBlock, HashToken, IdentToken, LiteralToken,
+    NumberToken, ParenthesesBlock, ParseError, PercentageToken, QualifiedRule,
+    SquareBracketsBlock, StringToken, UnicodeRangeToken, URLToken,
+    WhitespaceToken)
+
+from tinycss2.color3 import RGBA
+
+from webencodings import Encoding
+
+SKIP_COMMENTS = False
+SKIP_WHITESPACE = False
+
+
+def parse_declaration_list(tokens, skip_comments=False, skip_whitespace=False):
+    """
+    This method is the entry point to parsing the declaration list
+    """
+    global SKIP_WHITESPACE
+    global SKIP_COMMENTS
+
+    if skip_comments:
+        SKIP_COMMENTS = True
+    if skip_whitespace:
+        SKIP_WHITESPACE = True
+    result = []
+    for token in tokens:
+        if token.type == 'whitespace':
+            if not SKIP_WHITESPACE:
+                result.append(token)
+        elif token.type == 'comment':
+            if not SKIP_COMMENTS:
+                result.append(token)
+        elif token.type == 'at-keyword':
+            # result.append(_consume_at_rule(token, tokens))
+            print("At-rule spotted!")
+        elif token.type == 'ident':
+            declaration = _consume_declaration_in_list(token, tokens[tokens.index(token):])
+            if declaration:
+                declaration_as_json = to_json(declaration)
+                result.append(declaration_as_json)
+    return result
+
+
+def _consume_declaration_in_list(first_token, tokens):
+    """Like :func:`_parse_declaration`, but stop at the first ``;``."""
+    other_declaration_tokens = []
+    for token in tokens:
+        if token == first_token:
+            continue
+        elif token.type == 'whitespace' and SKIP_WHITESPACE:
+            continue
+        elif token.type == 'comment' and SKIP_COMMENTS:
+            continue
+        elif token == ';':
+            break
+        other_declaration_tokens.append(token)
+    return _parse_declaration(first_token, iter(other_declaration_tokens))
+
+
+def _parse_declaration(first_token, tokens):
+    """Parse a declaration.
+
+    Consume :obj:`tokens` until the end of the declaration or the first error.
+
+    :type first_token: :term:`component value`
+    :param first_token: The first component value of the rule.
+    :type tokens: :term:`iterator`
+    :param tokens: An iterator yielding :term:`component values`.
+    :returns:
+        A :class:`~tinycss2.ast.Declaration`
+        or :class:`~tinycss2.ast.ParseError`.
+
+    """
+    name = first_token
+    if name.type != 'ident':
+        return
+        # return ParseError(name.source_line, name.source_column, 'invalid',
+        #                   'Expected <ident> for declaration name, got %s.'
+        #                   % name.type)
+
+    colon = _next_significant(tokens)
+    if colon is None:
+        return
+        # return ParseError(name.source_line, name.source_column, 'invalid',
+        #                   "Expected ':' after declaration name, got EOF")
+    elif colon != ':':
+        return
+        # return ParseError(colon.source_line, colon.source_column, 'invalid',
+        #                   "Expected ':' after declaration name, got %s."
+        #                   % colon.type)
+
+    value = []
+    state = 'value'
+    for i, token in enumerate(tokens):
+        if state == 'value' and token == '!':
+            state = 'bang'
+            bang_position = i
+        elif state == 'bang' and token.type == 'ident' \
+                and token.lower_value == 'important':
+            state = 'important'
+        elif token.type not in ('whitespace', 'comment'):
+            state = 'value'
+        value.append(token)
+
+    if state == 'important':
+        del value[bang_position:]
+
+    return Declaration(name.source_line, name.source_column, name.value,
+                       name.lower_value, value, state == 'important')
+
+
+def _next_significant(tokens):
+    """Return the next significant (neither whitespace or comment) token.
+
+    :type tokens: :term:`iterator`
+    :param tokens: An iterator yielding :term:`component values`.
+    :returns: A :term:`component value`, or :obj:`None`.
+
+    """
+    for token in tokens:
+        if token.type not in ('whitespace', 'comment'):
+            return token
+
+
+def significant_tokens(tokens):
+    return [token for token in tokens if token.type not in ('whitespace', 'comment')]
+
+
+def _generic(func):
+    implementations = func()
+
+    @functools.wraps(func)
+    def run(value):
+        repr(value)  # Test that this does not raise.
+        return implementations[type(value)](value)
+    return run
+
+
+@_generic
+def to_json():
+    def numeric(t):
+        return [
+            t.representation, t.value,
+            'integer' if t.int_value is not None else 'number']
+    return {
+        type(None): lambda _: None,
+        str: lambda s: s,
+        int: lambda s: s,
+        list: lambda l: [to_json(el) for el in l],
+        set: lambda l: [to_json(el) for el in l],
+        tuple: lambda l: [to_json(el) for el in l],
+        Encoding: lambda e: e.name,
+        ParseError: lambda e: ['error', e.kind],
+
+        Comment: lambda t: '/* … */',
+        WhitespaceToken: lambda t: ' ',
+        LiteralToken: lambda t: t.value,
+        IdentToken: lambda t: t.value,
+        AtKeywordToken: lambda t: {'at-keyword', t.value},
+        HashToken: lambda t: {
+            'hash': t.value,
+            'id': t.is_identifier if t.is_identifier else 'unrestricted'
+        },
+        StringToken: lambda t: {'string', t.value},
+        URLToken: lambda t: {'url': t.value},
+        NumberToken: lambda t: ['number'] + numeric(t),
+        PercentageToken: lambda t: ['percentage'] + numeric(t),
+        DimensionToken: lambda t: ['dimension'] + numeric(t) + [t.unit],
+        UnicodeRangeToken: lambda t: ['unicode-range', t.start, t.end],
+
+        CurlyBracketsBlock: lambda t: ['{}'] + to_json(t.content),
+        SquareBracketsBlock: lambda t: ['[]'] + to_json(t.content),
+        ParenthesesBlock: lambda t: ['()'] + to_json(t.content),
+        FunctionBlock: lambda t: ['function', t.name] + to_json(t.arguments),
+
+        Declaration: lambda d: {
+            d.name: {
+                'values': to_json(d.value),
+                'important': d.important
+            }
+        },
+        AtRule: lambda r: ['at-rule', r.at_keyword, to_json(r.prelude),
+                           to_json(r.content)],
+        QualifiedRule: lambda r: {
+            'type': 'qualified rule',
+            'prelude': to_json(r.prelude),
+            'content': to_json(r.content)
+        },
+
+        RGBA: lambda v: [round(c, 10) for c in v],
+    }

--- a/tools/tinycss2_helper.py
+++ b/tools/tinycss2_helper.py
@@ -1,9 +1,11 @@
 """
 This helper class is for facilitating the adoption of the tinycss2 library
+https://github.com/Kozea/tinycss2
 """
 
 import functools
 
+# https://github.com/Kozea/tinycss2/blob/master/tinycss2/ast.py
 from tinycss2.ast import (
     AtKeywordToken, AtRule, Comment, CurlyBracketsBlock, Declaration,
     DimensionToken, FunctionBlock, HashToken, IdentToken, LiteralToken,
@@ -11,6 +13,7 @@ from tinycss2.ast import (
     SquareBracketsBlock, StringToken, UnicodeRangeToken, URLToken,
     WhitespaceToken)
 
+# https://github.com/Kozea/tinycss2/blob/master/tinycss2/color3.py
 from tinycss2.color3 import RGBA
 
 from webencodings import Encoding
@@ -19,6 +22,8 @@ SKIP_COMMENTS = False
 SKIP_WHITESPACE = False
 
 
+# Similar to parse_declaration_list in https://github.com/Kozea/tinycss2/blob/master/tinycss2/parser.py
+# Except that it accepts tokens rather than a string
 def parse_declaration_list(tokens, skip_comments=False, skip_whitespace=False):
     """Parse a :diagram:`declaration list` (which may also contain at-rules).
 
@@ -79,6 +84,8 @@ def parse_declaration_list(tokens, skip_comments=False, skip_whitespace=False):
     return result
 
 
+# Similar to _consume_declaration_in_list in https://github.com/Kozea/tinycss2/blob/master/tinycss2/parser.py
+# Changed to skip first_token in list of tokens, whitespace, and comments
 def _consume_declaration_in_list(first_token, tokens):
     """Like :func:`_parse_declaration`, but stop at the first ``;``."""
     other_declaration_tokens = []
@@ -95,6 +102,8 @@ def _consume_declaration_in_list(first_token, tokens):
     return _parse_declaration(first_token, iter(other_declaration_tokens))
 
 
+# The same as _parse_declaration in https://github.com/Kozea/tinycss2/blob/master/tinycss2/parser.py
+# Needed to be pulled out so that it was accessible to the modified _consume_declaration_in_list
 def _parse_declaration(first_token, tokens):
     """Parse a declaration.
 
@@ -139,6 +148,8 @@ def _parse_declaration(first_token, tokens):
                        name.lower_value, value, state == 'important')
 
 
+# The same as _next_significant in https://github.com/Kozea/tinycss2/blob/master/tinycss2/parser.py
+# Needed to be pulled out so that it was accessible to _parse_declaration
 def _next_significant(tokens):
     """Return the next significant (neither whitespace or comment) token.
 
@@ -152,6 +163,7 @@ def _next_significant(tokens):
             return token
 
 
+# Custom method
 def significant_tokens(tokens):
     """
     This method returns the significant tokens (neither whitespace or comment)
@@ -163,8 +175,9 @@ def significant_tokens(tokens):
     return [token for token in tokens if token.type not in ('whitespace', 'comment')]
 
 
-
-# The following was pulled from the tinycss2 testing suite to assist with JSON conversions
+# The following was pulled from the tinycss2 testing suite
+# https://github.com/Kozea/tinycss2/blob/master/tests/test_tinycss2.py to assist with JSON conversions.
+# The to_json() method was tweaked for a more pythonic JSON format of token serialization
 def _generic(func):
     implementations = func()
 


### PR DESCRIPTION
Closes https://cccs.atlassian.net/browse/AL-1996

A ton of things here:
- use BeautifulSoup to extract <style> elements into CSS files
- create a heuristic for suspicious CSS declarations
- Added a way to handle CSS stylesheets in MalwareJail
- Added functionality to facilitate the `top` object in JavaScript
- Limit number of characters in a line to look for IOCs in
- Added support for adding an EventListener object in MalwareJail
- Added support for extracting files created with the File object in MalwareJail
- Added a `tinycss2` helper method to assist with the context of how JsJaws manipulates CSS declaration tokens