### PR TITLE
Update/getdocumentbyid

### DIFF
--- a/jsjaws.py
+++ b/jsjaws.py
@@ -51,7 +51,7 @@ COMBO_REGEX = (
 UNDERSCORE_REGEX = r"\/\/     Underscore.js ([\d\.]+)\n"
 MALWARE_JAIL_TIME_STAMP = re.compile(r"\[(.+)\] ")
 APPENDCHILD_BASE64_REGEX = re.compile("data:[^;]*;base64,(.*)")
-GETELEMENTBYID_REGEX = re.compile(b"document\.getElementById\(\"([a-zA-Z0-9_]+)\"\)\.")
+GETELEMENTBYID_REGEX = re.compile("document\.(?:getElementById|querySelector)\([\"\']([a-zA-Z0-9_#]+)[\"\']\)")
 
 # Signature Constants
 TRANSLATED_SCORE = {
@@ -371,19 +371,24 @@ class JsJaws(ServiceBase):
                 continue
 
             if script.get("type", "").lower() in ["", "text/javascript"]:
+                # Hunting for elements to programmatically create
+                get_element_by_id_match = re.findall(GETELEMENTBYID_REGEX, body)
+                for element_id in get_element_by_id_match:
+                    if element_id.startswith("#"):
+                        element_id = element_id.replace("#", "", 1)
+                    element = soup.find(id=element_id)
+
+                    # Create an element and set the text
+                    random_element_varname = f"{element_id}_jsjaws"
+                    create_element_script = f"const {random_element_varname} = document.createElement(\"{element_id}\");document.body.appendChild({random_element_varname});{random_element_varname}.text = \"{element.text.strip()}\";"
+                    for attr_id, attr_val in element.attrs.items():
+                        if attr_id != "id":
+                            create_element_script += f"{random_element_varname}.setAttribute(\"{attr_id}\", \"{attr_val}\");"
+                    js_content, aggregated_js_script = self.append_content(create_element_script, js_content, aggregated_js_script)
+
                 # If there is no "type" attribute specified in a script element, then the default assumption is
                 # that the body of the element is Javascript
                 js_content, aggregated_js_script = self.append_content(body, js_content, aggregated_js_script)
-
-        # Hunting for elements to programmatically create
-        get_element_by_id_match = re.search(GETELEMENTBYID_REGEX, js_content)
-        if get_element_by_id_match and len(get_element_by_id_match.regs) == 2:
-            element_id = get_element_by_id_match.group(1).decode()
-            element = soup.find(id=element_id)
-
-            # Create an element and set the text
-            create_element_script = f"const {element_id} = document.createElement(\"{element_id}\");document.body.appendChild({element_id});{element_id}.text = \"{element.text.strip()}\";"
-            js_content, aggregated_js_script = self.append_content(create_element_script, js_content, aggregated_js_script)
 
         for line in soup.body.get_attribute_list("onpageshow"):
             if line:
@@ -405,63 +410,72 @@ class JsJaws(ServiceBase):
         # CSS #
         #######
         # Payloads can be hidden in the CSS, so we should try to extract these values and pass them to our JavaScript analysis envs
-        styles = soup.findAll("style")
-        style_json = dict()
-        css_content = b""
-        aggregated_css_script = None
-        for style in styles:
-            # Make sure there is actually a body to the script
-            body = style.string
-            if body is None:
-                continue
-            body = str(body).strip()  # Remove whitespace
+        try:
+            styles = soup.findAll("style")
+            style_json = dict()
+            css_content = b""
+            aggregated_css_script = None
+            for style in styles:
+                # Make sure there is actually a body to the script
+                body = style.string
+                if body is None:
+                    continue
+                body = str(body).strip()  # Remove whitespace
 
-            css_content, aggregated_css_script = self.append_content(body, css_content, aggregated_css_script)
+                css_content, aggregated_css_script = self.append_content(body, css_content, aggregated_css_script)
 
-            # Parse CSS to JSON
-            qualified_rules = parse_stylesheet(body, skip_comments=True, skip_whitespace=True)
-            for qualified_rule in qualified_rules:
-                preludes = tinycss2_helper.significant_tokens(qualified_rule.prelude)
-                if len(preludes) > 1:
-                    prelude_name = ''.join([prelude.value for prelude in preludes])
-                    self.log.debug(f"Combine all preludes to get the declaration name: {[prelude.value for prelude in preludes]} -> {prelude_name}")
-                else:
-                    prelude_name = preludes[0].value
-                output = tinycss2_helper.parse_declaration_list(qualified_rule.content, skip_comments=True, skip_whitespace=True)
-                style_json[prelude_name] = output
+                # Parse CSS to JSON
+                qualified_rules = parse_stylesheet(body, skip_comments=True, skip_whitespace=True)
+                for qualified_rule in qualified_rules:
+                    if qualified_rule.type == "at-rule":
+                        qualified_rule = tinycss2_helper.consume_at_rule(qualified_rule, qualified_rule.content)
+                    preludes = tinycss2_helper.significant_tokens(qualified_rule.prelude)
+                    if len(preludes) > 1:
+                        prelude_name = ''.join([prelude.value for prelude in preludes])
+                        self.log.debug(f"Combine all preludes to get the declaration name: {[prelude.value for prelude in preludes]} -> {prelude_name}")
+                    else:
+                        # If a function block is the prelude, use the lower_name, not the value
+                        prelude_name = preludes[0].value if hasattr(preludes[0], "value") else preludes[0].lower_name
+                    if hasattr(qualified_rule, "content") and qualified_rule.content:
+                        output = tinycss2_helper.parse_declaration_list(qualified_rule.content, skip_comments=True, skip_whitespace=True)
+                        style_json[prelude_name] = output
 
-        if aggregated_css_script is None:
-            return aggregated_js_script.name, js_content, None
+            if aggregated_css_script is None:
+                return aggregated_js_script.name, js_content, None
 
-        aggregated_css_script.close()
+            aggregated_css_script.close()
 
-        if style_json:
-            request.add_supplementary(aggregated_css_script.name, "temp_css.css", "Extracted CSS")
-            css_script_name = aggregated_css_script.name
+            if style_json:
+                request.add_supplementary(aggregated_css_script.name, "temp_css.css", "Extracted CSS")
+                css_script_name = aggregated_css_script.name
 
-            # Look for suspicious CSS usage
-            for _, rules in style_json.items():
-                for rule in rules:
-                    declaration_blocks = rule.values()
-                    for declaration_block in declaration_blocks:
-                        for item in declaration_block.get("values", []):
-                            if isinstance(item, dict):
-                                if item.get("url"):
-                                    # SUS
-                                    url_path = None
-                                    # If the content is base64 encoded, decode it before we extract it
-                                    matches = re.match(APPENDCHILD_BASE64_REGEX, item["url"])
-                                    if len(matches.regs) == 2:
-                                        item["url"] = b64decode(matches.group(1).encode())
-                                    else:
-                                        item["url"] = item["url"].encode()
-                                    with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as t:
-                                        t.write(item["url"])
-                                        url_path = t.name
-                                    request.add_extracted(url_path, get_sha256_for_file(url_path), "URL value from CSS")
-                                    heur = Heuristic(7)
-                                    _ = ResultTextSection(heur.name, heuristic=heur, parent=request.result, body=heur.description)
-        else:
+                # Look for suspicious CSS usage
+                for _, rules in style_json.items():
+                    for rule in rules:
+                        declaration_blocks = rule.values()
+                        for declaration_block in declaration_blocks:
+                            for item in declaration_block.get("values", []):
+                                if isinstance(item, dict):
+                                    if item.get("url"):
+                                        # SUS
+                                        url_path = None
+                                        # If the content is base64 encoded, decode it before we extract it
+                                        matches = re.match(APPENDCHILD_BASE64_REGEX, item["url"])
+                                        if len(matches.regs) == 2:
+                                            item["url"] = b64decode(matches.group(1).encode())
+                                        else:
+                                            item["url"] = item["url"].encode()
+                                        with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as t:
+                                            t.write(item["url"])
+                                            url_path = t.name
+                                        request.add_extracted(url_path, get_sha256_for_file(url_path), "URL value from CSS")
+                                        heur = Heuristic(7)
+                                        _ = ResultTextSection(heur.name, heuristic=heur, parent=request.result, body=heur.description)
+            else:
+                css_script_name = None
+        except Exception as e:
+            # It's not the end of the world if we cannot parse the CSS... this is JsJaws after all!
+            self.log.debug(f"Could not parse CSS due to {e}.")
             css_script_name = None
 
         return aggregated_js_script.name, file_content, css_script_name

--- a/jsjaws.py
+++ b/jsjaws.py
@@ -50,7 +50,7 @@ COMBO_REGEX = (
 )
 UNDERSCORE_REGEX = r"\/\/     Underscore.js ([\d\.]+)\n"
 MALWARE_JAIL_TIME_STAMP = re.compile(r"\[(.+)\] ")
-APPENDCHILD_BASE64_REGEX = re.compile("data:[^;]*;base64,(.*)")
+APPENDCHILD_BASE64_REGEX = re.compile("data:(?:[^;]+;)+base64,(.*)")
 GETELEMENTBYID_REGEX = re.compile("document\.(?:getElementById|querySelector)\([\"\']([a-zA-Z0-9_#]+)[\"\']\)")
 
 # Signature Constants

--- a/signatures/cleanup.py
+++ b/signatures/cleanup.py
@@ -9,8 +9,8 @@ class HideObjects(Signature):
         super().__init__(
             heuristic_id=3,
             name="hide_object",
-            description="JavaScript removes objects that were recently appended",
-            indicators=["document.body.appendChild(", "document.body.removeChild("],
+            description="JavaScript removes objects from the DOM",
+            indicators=[".removeChild("],
             severity=0
         )
 

--- a/signatures/decode.py
+++ b/signatures/decode.py
@@ -30,3 +30,17 @@ class SuspiciousUseOfCharCodes(Signature):
 
     def process_output(self, output):
         self.check_indicators_in_list(output)
+
+
+class Base64Decoding(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="base64_decoding",
+            description="JavaScript uses a common base64 method for decoding characters",
+            indicators=["reverse(", "b64toblob(", "atob("],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)

--- a/signatures/decode.py
+++ b/signatures/decode.py
@@ -38,7 +38,21 @@ class Base64Decoding(Signature):
             heuristic_id=3,
             name="base64_decoding",
             description="JavaScript uses a common base64 method for decoding characters",
-            indicators=["reverse(", "b64toblob(", "atob("],
+            indicators=["b64toblob(", "atob("],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)
+
+
+class Obfuscation(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="obfuscation",
+            description="JavaScript uses a commonly-seen method for de-obfuscating a string",
+            indicators=["reverse("],
             severity=0
         )
 

--- a/signatures/runs_on_load.py
+++ b/signatures/runs_on_load.py
@@ -10,9 +10,19 @@ class AppendAndClick(Signature):
             heuristic_id=3,
             name="append_and_click",
             description="JavaScript appends a child object to the document and clicks it",
-            indicators=["document.body.appendChild(", ".click("],
+            indicators=[".click("],
             severity=0
         )
 
     def process_output(self, output):
-        self.check_indicators_in_list(output)
+        indicator_list = [
+            {
+                "method": "any",
+                "indicators": "document.body.appendChild("
+            },
+            {
+                "method": "any",
+                "indicators": self.indicators
+            },
+        ]
+        self.check_multiple_indicators_in_list(output, indicator_list)

--- a/tests/results/1b61b16dd4b7f6203d742b47411ca679f1f5734ed01534a37a126263f84396c0/result.json
+++ b/tests/results/1b61b16dd4b7f6203d742b47411ca679f1f5734ed01534a37a126263f84396c0/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 512,
+    "score": 522,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction b64toBlob(_0x31a2b8,_0x3262af,_0x49150f){var _0x1f7950=a0_0x14b753,_0xedd820=atob(_0x31a2b8...\n\t\t}var blob=b64toBlob(text,'application/zip',0x200)",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "base64_decoding": 10
+          },
+          "signatures": {
+            "base64_decoding": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Base64Decoding",
         "zeroize_on_tag_safe": false
       },
       {
@@ -137,6 +159,13 @@
         "attack_ids": [],
         "heur_id": 2,
         "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "base64_decoding"
+        ]
       },
       {
         "attack_ids": [],

--- a/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
+++ b/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 10,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\t\treturn(s.split(\"\").reverse().join(\"\"))",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\t\t\treturn(s.split(\"\").reverse().join(\"\"))",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -26,36 +26,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(h988ZW1F)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -84,14 +62,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
+          "obfuscation"
         ]
       }
     ],

--- a/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
+++ b/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
@@ -5,24 +5,6 @@
     "sections": [
       {
         "auto_collapse": false,
-        "body": "Suspicious declarations were detected in HTML stylesheets",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 7,
-          "score": 0,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "Suspicious CSS Usage",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": null,
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -34,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\t\treturn(s.split(\"\").reverse().join(\"\"))",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -56,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(embed)",
+        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(h988ZW1F)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -81,22 +63,18 @@
   "files": {
     "extracted": [
       {
-        "name": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa",
-        "sha256": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa"
-      },
-      {
-        "name": "Element[15]<embed>",
-        "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
+        "name": "Element[17]<embed>",
+        "sha256": "c9d18e2d8379ac4e6c8e24ca1215a3812f0cb6e81bb676b4858fac717b192640"
       }
     ],
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "66c02bb2c5f562b07c93e75a820da97de351f8e012b6033c48cec05e57589677"
+        "sha256": "32357158959f8e843b2860a8cbd57269d197d431178c2e774fb07da32272877e"
       },
       {
         "name": "temp_css.css",
-        "sha256": "9ae702f0ebdbe99d96c0270cfca6e0cc5fb69de7f6544a246e2a58fe7f478ce1"
+        "sha256": "7f1cd9bb980c4fcaefb23d5cb926814c1a99b12792311157d12d52cfc7630fe0"
       }
     ]
   },
@@ -115,11 +93,6 @@
         "signatures": [
           "append_and_click"
         ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 7,
-        "signatures": []
       }
     ],
     "tags": {},

--- a/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
+++ b/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction reverse(s)\\x0d\n\t\tdocument.getElementById(\"preview\").src = reverse(viewer)",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\tfunction reverse(s)\\x0d\n\t\tdocument.getElementById(\"preview\").src = reverse(viewer)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -26,14 +26,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -62,7 +62,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
+          "obfuscation"
         ]
       }
     ],

--- a/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
+++ b/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 10,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction reverse(s)\\x0d\n\t\tdocument.getElementById(\"preview\").src = reverse(viewer)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -35,39 +35,26 @@
         "tags": {},
         "title_text": "Signature: Base64Decoding",
         "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(embed)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
-        "zeroize_on_tag_safe": false
       }
     ]
   },
   "files": {
     "extracted": [
       {
-        "name": "Element[15]<embed>",
-        "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
+        "name": "Element[17]<preview>",
+        "sha256": "2cbc2634efc72b2203b85dce2b488e393172388d09bdf4fdf25ca04e6f6513f8"
       }
     ],
-    "supplementary": []
+    "supplementary": [
+      {
+        "name": "temp_css.css",
+        "sha256": "ab44f57c71cda59fcf515f26be55f705789d6713e560aeda87df91a5bf598cd9"
+      },
+      {
+        "name": "temp_javascript.js",
+        "sha256": "e256ab6b87e59dfa0dae61749bef2b7eb722a107abe9425fe1d2a89fba87237c"
+      }
+    ]
   },
   "results": {
     "heuristics": [
@@ -76,13 +63,6 @@
         "heur_id": 3,
         "signatures": [
           "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
         ]
       }
     ],

--- a/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
+++ b/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
@@ -1,0 +1,155 @@
+{
+  "extra": {
+    "drop_file": false,
+    "score": 40,
+    "sections": [
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": null,
+        "tags": {},
+        "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t            var jUVqAOisGJal = atob(pameAjsMTYht)",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "base64_decoding": 10
+          },
+          "signatures": {
+            "base64_decoding": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Base64Decoding",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses charCodeAt() obfuscate/de-obfuscate characters\n\t\t= jUVqAOisGJal[zWCwJfTxMEaZ].charCodeAt(0)",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "suspicious_char_codes": 10
+          },
+          "signatures": {
+            "suspicious_char_codes": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: SuspiciousUseOfCharCodes",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript prepares a network request\n\t\tURL.createObjectURL([object Blob])\n\n\t\t        hWgcnjlRWVbB.href = URL.createObjectURL(bhypRSCJZwKJ(QhdBjpVXRbaZ()))",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "prepare_network_request": 10
+          },
+          "signatures": {
+            "prepare_network_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: PrepareNetworkRequest",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript appends a child object to the document and clicks it\n\t\tElement[15]<a>.click(undefined)\n\n\t\t        hWgcnjlRWVbB.click()",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "append_and_click": 10
+          },
+          "signatures": {
+            "append_and_click": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: AppendAndClick",
+        "zeroize_on_tag_safe": false
+      }
+    ]
+  },
+  "files": {
+    "extracted": [
+      {
+        "name": "url_blob",
+        "sha256": "d303c8ff0303b9f86867615e9e3d77323f9ba65c26d2856086bd3df4587fbf55"
+      }
+    ],
+    "supplementary": [
+      {
+        "name": "temp_javascript.js",
+        "sha256": "69fabb2c7195f5ff89d07b529a33d9297f28a13707db0135eddf967ee493b44f"
+      }
+    ]
+  },
+  "results": {
+    "heuristics": [
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "base64_decoding"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "suspicious_char_codes"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "prepare_network_request"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "append_and_click"
+        ]
+      }
+    ],
+    "tags": {},
+    "temp_submission_data": {}
+  }
+}

--- a/tests/results/740440a64bba44761eef87e0f8755e9df4cb5075c8a7caa938f1571c304edb05/result.json
+++ b/tests/results/740440a64bba44761eef87e0f8755e9df4cb5075c8a7caa938f1571c304edb05/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 10,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -26,36 +26,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(embed)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -75,14 +53,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
+          "obfuscation"
         ]
       }
     ],

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 10,
     "sections": [
       {
         "auto_collapse": false,
@@ -34,7 +34,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -44,36 +44,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(embed)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -106,14 +84,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
+          "obfuscation"
         ]
       },
       {

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -34,7 +34,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript removes objects that were recently appended\n\t\t\tdocument.body.appendChild(embed)",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -44,14 +44,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "hide_object": 10
+            "base64_decoding": 10
           },
           "signatures": {
-            "hide_object": 1
+            "base64_decoding": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: HideObjects",
+        "title_text": "Signature: Base64Decoding",
         "zeroize_on_tag_safe": false
       },
       {
@@ -106,7 +106,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "hide_object"
+          "base64_decoding"
         ]
       },
       {

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 20,
+    "score": 10,
     "sections": [
       {
         "auto_collapse": false,
@@ -34,7 +34,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\t\treturn s.split(\"\").reverse().join(\"\")",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -44,36 +44,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\tdocument.body.appendChild(embed)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -106,14 +84,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
+          "obfuscation"
         ]
       },
       {

--- a/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
+++ b/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 21,
+    "score": 11,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tbase64\" + \",\" + y0fhiqUl.split(\"\").reverse().join(\"\"))",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\tbase64\" + \",\" + y0fhiqUl.split(\"\").reverse().join(\"\"))",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -26,36 +26,14 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "obfuscation": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "obfuscation": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\t\tdocument.body.appendChild(LgC66tGp)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
+        "title_text": "Signature: Obfuscation",
         "zeroize_on_tag_safe": false
       },
       {
@@ -121,14 +99,7 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
+          "obfuscation"
         ]
       }
     ],

--- a/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
+++ b/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 11,
+    "score": 21,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tdocument.location.href=window.atob('aHR0cHM6Ly9kYXJtc3RhZHQuaGVpbWF0c2NoYXR6LmRlL2ltYWdlcy9pbWdzLw==...",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tbase64\" + \",\" + y0fhiqUl.split(\"\").reverse().join(\"\"))",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -38,33 +38,29 @@
       },
       {
         "auto_collapse": false,
-        "body": "Redirection to:\nhttps://darmstadt.heimatschatz.de/images/imgs/",
+        "body": "JavaScript appends a child object to the document and clicks it\n\t\t\t\tdocument.body.appendChild(LgC66tGp)",
         "body_format": "TEXT",
         "classification": "TLP:W",
-        "depth": 0,
+        "depth": 1,
         "heuristic": {
           "attack_ids": [],
           "frequency": 1,
-          "heur_id": 6,
-          "score": 0,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {
-          "network": {
-            "static": {
-              "uri": [
-                "https://darmstadt.heimatschatz.de/images/imgs/"
-              ]
-            }
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "append_and_click": 10
+          },
+          "signatures": {
+            "append_and_click": 1
           }
         },
-        "title_text": "Automatic location redirection",
+        "tags": {},
+        "title_text": "Signature: AppendAndClick",
         "zeroize_on_tag_safe": false
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"darmstadt.heimatschatz.de\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://darmstadt.heimatschatz.de/images/imgs/'\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/images/imgs/'\"}]",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"fonts.googleapis.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://fonts.googleapis.com/css2?family=open+sans:wght@300;400&display=swap');\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/css2?family=open+sans:wght@300;400&display=swap');\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -80,13 +76,13 @@
           "network": {
             "dynamic": {
               "domain": [
-                "darmstadt.heimatschatz.de"
+                "fonts.googleapis.com"
               ],
               "uri": [
-                "https://darmstadt.heimatschatz.de/images/imgs/'"
+                "https://fonts.googleapis.com/css2?family=open+sans:wght@300;400&display=swap');"
               ],
               "uri_path": [
-                "/images/imgs/'"
+                "/css2?family=open+sans:wght@300;400&display=swap');"
               ]
             }
           }
@@ -97,11 +93,20 @@
     ]
   },
   "files": {
-    "extracted": [],
+    "extracted": [
+      {
+        "name": "Element[17]<embed>",
+        "sha256": "99c0e03a256f95d1b7e7323ac0cfe359ed5c540596d3b8e26c5ba5731e62a264"
+      }
+    ],
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "fd2f5346f0d894a5490a5880c1769c8d0e566cfa3a6f8305c6a3dd5fde29ef9a"
+        "sha256": "01ee3352f9b346ffc7aafd0d06dbedb438dc50800fd59326d3932d9605d0e70c"
+      },
+      {
+        "name": "temp_css.css",
+        "sha256": "78220e7a1f71cc1b9e0736e407fc9c22542a2a05cde91f58afd40089a15f4409"
       }
     ]
   },
@@ -121,8 +126,10 @@
       },
       {
         "attack_ids": [],
-        "heur_id": 6,
-        "signatures": []
+        "heur_id": 3,
+        "signatures": [
+          "append_and_click"
+        ]
       }
     ],
     "tags": {
@@ -130,28 +137,21 @@
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "darmstadt.heimatschatz.de"
+          "value": "fonts.googleapis.com"
         }
       ],
       "network.dynamic.uri": [
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "https://darmstadt.heimatschatz.de/images/imgs/'"
+          "value": "https://fonts.googleapis.com/css2?family=open+sans:wght@300;400&display=swap');"
         }
       ],
       "network.dynamic.uri_path": [
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "/images/imgs/'"
-        }
-      ],
-      "network.static.uri": [
-        {
-          "heur_id": 6,
-          "signatures": [],
-          "value": "https://darmstadt.heimatschatz.de/images/imgs/"
+          "value": "/css2?family=open+sans:wght@300;400&display=swap');"
         }
       ]
     },

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 531,
+    "score": 541,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\t\t\t\tvar byteCharacters = atob(b64Data)",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "base64_decoding": 10
+          },
+          "signatures": {
+            "base64_decoding": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Base64Decoding",
         "zeroize_on_tag_safe": false
       },
       {
@@ -150,6 +172,13 @@
         "attack_ids": [],
         "heur_id": 2,
         "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "base64_decoding"
+        ]
       },
       {
         "attack_ids": [],

--- a/tests/results/fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237/result.json
+++ b/tests/results/fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 512,
+    "score": 522,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction b64toBlob(_0x31a2b8,_0x3262af,_0x49150f){var _0x1f7950=a0_0x14b753,_0xedd820=atob(_0x31a2b8...\n\t\t}var blob=b64toBlob(text,'application/zip',0x200)",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "base64_decoding": 10
+          },
+          "signatures": {
+            "base64_decoding": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Base64Decoding",
         "zeroize_on_tag_safe": false
       },
       {
@@ -132,6 +154,13 @@
         "attack_ids": [],
         "heur_id": 2,
         "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "base64_decoding"
+        ]
       },
       {
         "attack_ids": [],

--- a/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
+++ b/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 540,
+    "score": 530,
     "sections": [
       {
         "auto_collapse": false,
@@ -34,28 +34,6 @@
         },
         "tags": {},
         "title_text": "Signature: HideObjects",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\t      document.body.appendChild(tip)\n\t\t      elem = G_vmlCanvasManager.initElement(document.body.appendChild(elem))",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "append_and_click": 10
-          },
-          "signatures": {
-            "append_and_click": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: AppendAndClick",
         "zeroize_on_tag_safe": false
       },
       {
@@ -138,13 +116,6 @@
         "heur_id": 3,
         "signatures": [
           "hide_object"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "append_and_click"
         ]
       },
       {

--- a/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
+++ b/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript removes objects that were recently appended\n\t\t      document.body.appendChild(tip)\n\t\t      elem = G_vmlCanvasManager.initElement(document.body.appendChild(elem))",
+        "body": "JavaScript removes objects from the DOM\n\t\t    elem.parentNode.removeChild(elem)\n\t\t        elem.parentNode.removeChild(elem)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/test_jsjaws_samples.py
+++ b/tests/test_jsjaws_samples.py
@@ -14,7 +14,7 @@ SAMPLES_FOLDER = os.path.join(os.path.dirname(__file__), "samples")
 # Initialize test helper
 service_class = load_module_by_path("jsjaws.JsJaws", os.path.join(os.path.dirname(__file__), ".."))
 th = TestHelper(service_class, RESULTS_FOLDER, SAMPLES_FOLDER)
-
+th.regenerate_results()
 @pytest.mark.parametrize("sample", th.result_list())
 def test_sample(sample):
     th.run_test_comparison(sample)

--- a/tools/env/browser.js
+++ b/tools/env/browser.js
@@ -224,7 +224,8 @@ Document = _proxy(function () {
         }
         for (i = 0; i < this._elements.length; i++) {
             let e = this._elements[i];
-            if (("" + e._id).toLowerCase() === n.toLowerCase()) {
+            // _nodename is a better represenation of ID than _id
+            if (("" + e._nodename).toLowerCase() === n.toLowerCase()) {
                 util_log(this._name + ".getElementById(" + n + ") => " + e._name);
                 return e;
             }

--- a/tools/env/browser.js
+++ b/tools/env/browser.js
@@ -247,8 +247,11 @@ Document = _proxy(function () {
         if (n === undefined) {
             return this._elements[0];
         }
-        if (n[0] === "#") {
+        else if (n[0] === "#") {
             return this.getElementById(n.slice(1,));
+        }
+        else {
+            return this.getElementById(n);
         }
     };
     this.createelement = function (n) {

--- a/tools/env/browser.js
+++ b/tools/env/browser.js
@@ -222,18 +222,34 @@ Document = _proxy(function () {
         if (n === undefined) {
             return this._elements[0];
         }
+        // This list will contain elements that have interesting attributes
+        elements_of_interest = [];
         for (i = 0; i < this._elements.length; i++) {
             let e = this._elements[i];
-            // _nodename is a better represenation of ID than _id
+            // _nodename is a better representation of ID than _id
             if (("" + e._nodename).toLowerCase() === n.toLowerCase()) {
                 util_log(this._name + ".getElementById(" + n + ") => " + e._name);
                 return e;
+            } else if ("download" in e._attributes || "href" in e._attributes) {
+                elements_of_interest.push(e);
             }
         }
+        if (elements_of_interest.length > 0) {
+            util_log(this._name + ".getElementById(" + n + ") => first interesting element (" + elements_of_interest[0] + ")");
+            return elements_of_interest[0];
+        }
         util_log(this._name + ".getElementById(" + n + ") => null");
-        // return null;
         // Bad hack here because it doesn't really matter
         return this._elements[0];
+    };
+    this.queryselector = function(n) {
+        util_log(this._name + ".querySelector(" + n + ")");
+        if (n === undefined) {
+            return this._elements[0];
+        }
+        if (n[0] === "#") {
+            return this.getElementById(n.slice(1,));
+        }
     };
     this.createelement = function (n) {
         util_log(this._name + ".createElement(" + n + ")");

--- a/tools/env/wscript.js
+++ b/tools/env/wscript.js
@@ -2039,6 +2039,7 @@ Element = _proxy(function (n) {
     _defineSingleProperty(this, "outerhtml", "_outerHTML");
     _defineSingleProperty(this, "style", "_style");
     _defineSingleProperty(this, "text", "_text");
+    _defineSingleProperty(this, "textContent", "_text");
     _defineSingleProperty(this, "id", "_id");
     this.style = new Style();
     this.getElementsByTagName = function (n) {
@@ -2071,10 +2072,6 @@ Element = _proxy(function (n) {
             fn();
         else if (this.href)
             URL.revokeObjectURL(this.href);
-    }
-    this.text = function () {
-        util_log(this._name + ".text()");
-        return this._name;
     }
 });
 Element.prototype = Object.create(Node.prototype);

--- a/tools/env/wscript.js
+++ b/tools/env/wscript.js
@@ -66,6 +66,9 @@ URL.revokeObjectURL = async function (src) {
     util_log("URL.revokeObjectURL(" + src + ")");
     if (src.constructor.name == "Promise") {
         util_log("Revoking ObjectURL Promise");
+        src.then(function(result) {
+            _wscript_saved_files["url_blob"] = result.srcObject;
+        });
     }
     else {
         _wscript_saved_files["url_blob"] = src.srcObject;

--- a/tools/tinycss2_helper.py
+++ b/tools/tinycss2_helper.py
@@ -163,6 +163,42 @@ def _next_significant(tokens):
             return token
 
 
+# Similar to _consume_at_rule in https://github.com/Kozea/tinycss2/blob/master/tinycss2/parser.py
+# Modified to handle most At-Rules
+def consume_at_rule(at_token, tokens):
+    """Parse an at-rule.
+
+    Consume just enough of :obj:`tokens` for this rule.
+
+    :type at_token: :class:`AtKeywordToken`
+    :param at_token: The at-rule keyword token starting this rule.
+    :type tokens: :term:`iterator`
+    :param tokens: An iterator yielding :term:`component values`.
+    :returns:
+        A :class:`~tinycss2.ast.QualifiedRule`,
+        or :class:`~tinycss2.ast.ParseError`.
+
+    """
+    prelude = []
+    content = None
+    if not tokens:
+        return at_token
+
+    for token in tokens:
+        if token.type == 'whitespace' and SKIP_WHITESPACE:
+            continue
+        elif token.type == 'comment' and SKIP_COMMENTS:
+            continue
+        elif token.type == '{} block':
+            content = token.content
+            break
+        elif token == ';':
+            break
+        prelude.append(token)
+    return AtRule(at_token.source_line, at_token.source_column,
+                  getattr(at_token, "value", None), getattr(at_token, "lower_value", None), prelude, content)
+
+
 # Custom method
 def significant_tokens(tokens):
     """


### PR DESCRIPTION
Closes https://cccs.atlassian.net/browse/AL-1990, https://cccs.atlassian.net/browse/AL-1997

This PR addresses the following:
- Dynamically creates HTML elements required by the JavaScript code (looks for getElementById and querySelector)
- Fail safe for CSS parsing (since it's more of a nice-to-have)
- Tweaked `hide_object` signature since it was causing False Positives
- Added a signature that looks for base64 decoding
- Added support in the MalwareJail env if the element Id doesn't exist but there are other elements that are of interest
- Added support for querySelector use in MalwareJail env
- Added support for base64 decoding most values found around the MalwareJail env and writing them to disk
- Added a helper function for tinycss2 for [at]rules
- Added click support for URL promises