### PR TITLE
See PR description for details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV SERVICE_PATH jsjaws.JsJaws
 # Get required apt packages
 USER root
 RUN apt-get update && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh && rm /tmp/nodesource_setup.sh
+RUN curl -sL https://deb.nodesource.com/setup_19.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh && rm /tmp/nodesource_setup.sh
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
 
 # Switch to assemblyline user

--- a/jsjaws.py
+++ b/jsjaws.py
@@ -66,6 +66,9 @@ TRANSLATED_SCORE = {
 # Default cap of 10k lines of stdout from tools
 STDOUT_LIMIT = 10000
 
+# These are commonly found strings in MalwareJail output that should not be flagged as domains
+FP_DOMAINS = ["ModuleJob.run", ".zip"]
+
 
 class JsJaws(ServiceBase):
     def __init__(self, config: Optional[Dict] = None) -> None:
@@ -136,7 +139,7 @@ class JsJaws(ServiceBase):
             self.malware_jail_sandbox_env_dir, self.malware_jail_sandbox_env_dump
         )
         root_dir = path.dirname(path.abspath(__file__))
-        self.path_to_jailme_js = path.join(root_dir, "tools/malwarejail/jailme.cjs")
+        self.path_to_jailme_js = path.join(root_dir, "tools/malwarejail/jailme.js")
         self.path_to_boxjs = path.join(root_dir, "tools/node_modules/box-js/run.js")
         self.path_to_jsxray = path.join(root_dir, "tools/js-x-ray-run.js")
         self.malware_jail_urls_json_path = path.join(self.malware_jail_payload_extraction_dir, "urls.json")
@@ -966,6 +969,12 @@ class JsJaws(ServiceBase):
                 log_line = line
             if len(log_line) > 10000:
                 log_line = truncate(log_line, 10000)
+
+            # Remove domains that are most likely false positives in MalwareJail output
+            if any(fp_domain in log_line for fp_domain in FP_DOMAINS):
+                for fp_domain in FP_DOMAINS:
+                    log_line = log_line.replace(fp_domain, "<replaced>")
+
             extract_iocs_from_text_blob(log_line, malware_jail_res_sec)
 
             if log_line.startswith("Exception occurred in "):

--- a/signatures/blob_usage.py
+++ b/signatures/blob_usage.py
@@ -1,0 +1,32 @@
+"""
+These are all of the signatures related to blob usage
+"""
+from signatures.abstracts import Signature
+
+
+class CreatesBlob(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="creates_blob",
+            description="JavaScript creates a Blob object",
+            indicators=["new Blob(", "new File("],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)
+
+
+class CreatesObjectURL(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="creates_object_url",
+            description="JavaScript creates an object URL with a blob",
+            indicators=["createObjectURL("],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)

--- a/signatures/decode.py
+++ b/signatures/decode.py
@@ -38,7 +38,7 @@ class Base64Decoding(Signature):
             heuristic_id=3,
             name="base64_decoding",
             description="JavaScript uses a common base64 method for decoding characters",
-            indicators=["b64toblob(", "atob("],
+            indicators=["b64toblob(", "atob(", "b64blb("],
             severity=0
         )
 

--- a/signatures/network.py
+++ b/signatures/network.py
@@ -10,7 +10,7 @@ class PrepareNetworkRequest(Signature):
             heuristic_id=3,
             name="prepare_network_request",
             description="JavaScript prepares a network request",
-            indicators=[".setRequestHeader(", "User-Agent", "XMLHttpRequest(", "URL.createObjectURL("],
+            indicators=[".setRequestHeader(", "User-Agent", "XMLHttpRequest("],
             severity=0
         )
 

--- a/signatures/save_to_file.py
+++ b/signatures/save_to_file.py
@@ -5,7 +5,7 @@ from signatures.abstracts import Signature
 
 
 # List of commands used to save a file to disk
-save_commands = ["SaveToFile", "msSaveOrOpenBlob(", "saveAs("]
+save_commands = ["SaveToFile", "msSaveOrOpenBlob(", "saveAs(", "new File("]
 
 
 class SaveToFile(Signature):

--- a/signatures/suspicious_process.py
+++ b/signatures/suspicious_process.py
@@ -10,7 +10,7 @@ class SuspiciousProcess(Signature):
             heuristic_id=3,
             name="suspicious_process",
             description="JavaScript uses a suspicious process",
-            indicators=["winmgmts", "eval(", "uneval("],
+            indicators=["winmgmts", "eval(", "uneval(", "new Worker("],
             severity=0
         )
 

--- a/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
+++ b/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 40,
+    "score": 50,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,50 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...\n\t\t            return new Blob(xrXkOsltcOME, { type: ali + 'ct################et-s############tre######...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_blob": 10
+          },
+          "signatures": {
+            "creates_blob": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesBlob",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n\n\t\t        hWgcnjlRWVbB.href = URL.createObjectURL(bhypRSCJZwKJ(QhdBjpVXRbaZ()))",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_object_url": 10
+          },
+          "signatures": {
+            "creates_object_url": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesObjectURL",
         "zeroize_on_tag_safe": false
       },
       {
@@ -60,28 +104,6 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript prepares a network request\n\t\tURL.createObjectURL([object Blob])\n\n\t\t        hWgcnjlRWVbB.href = URL.createObjectURL(bhypRSCJZwKJ(QhdBjpVXRbaZ()))",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "prepare_network_request": 10
-          },
-          "signatures": {
-            "prepare_network_request": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: PrepareNetworkRequest",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "JavaScript appends a child object to the document and clicks it\n\t\tElement[15]<a>.click(undefined)\n\n\t\t        hWgcnjlRWVbB.click()",
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -107,7 +129,7 @@
   "files": {
     "extracted": [
       {
-        "name": "url_blob",
+        "name": "ObjectURL[19]",
         "sha256": "d303c8ff0303b9f86867615e9e3d77323f9ba65c26d2856086bd3df4587fbf55"
       }
     ],
@@ -124,6 +146,20 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "creates_blob"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "creates_object_url"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "base64_decoding"
         ]
       },
@@ -132,13 +168,6 @@
         "heur_id": 3,
         "signatures": [
           "suspicious_char_codes"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "prepare_network_request"
         ]
       },
       {

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 541,
+    "score": 550,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,51 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\t\t\t\tvar byteCharacters = atob(b64Data)",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,20,0,1,0,8,0,234,145,70,85,152,108,183,42,144,114,3,0,0,248,6,0,16,0,0,0,79,118,1...\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob],[object Object])\n\n\t\t\t\t\t\tvar blob = new Blob(byteArrays, {type: \"application/zip\"})\n\t\t\t\t\t\tlet file = new File([blob], \"attachment.zip\", {type: \"application/zip\"})",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_blob": 10
+          },
+          "signatures": {
+            "creates_blob": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesBlob",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_object_url": 10
+          },
+          "signatures": {
+            "creates_object_url": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesObjectURL",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t\t\t\tfunction b64blb(b64Data, sliceSize)\n\t\t\t\t\t\tvar byteCharacters = atob(b64Data)\n\t\t\t\t\tvar blob = b64blb(content, 512)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -60,29 +104,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript prepares a network request\n\t\tURL.createObjectURL([object Blob])\n",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "prepare_network_request": 10
-          },
-          "signatures": {
-            "prepare_network_request": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: PrepareNetworkRequest",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript writes data to disk\n\t\tsaveAs([object Blob], attachment.zip)\n",
+        "body": "JavaScript writes data to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\t\t\t\t\tlet file = new File([blob], \"attachment.zip\", {type: \"application/zip\"})",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -104,7 +126,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript writes archive file to disk\n\t\tsaveAs([object Blob], attachment.zip)\n",
+        "body": "JavaScript writes archive file to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\t\t\t\t\tlet file = new File([blob], \"attachment.zip\", {type: \"application/zip\"})",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -122,32 +144,6 @@
         },
         "tags": {},
         "title_text": "Signature: WritesArchive",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"attachment.zip\"}]",
-        "body_format": "TABLE",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 2,
-          "score": 1,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {
-          "network": {
-            "dynamic": {
-              "domain": [
-                "attachment.zip"
-              ]
-            }
-          }
-        },
-        "title_text": "MalwareJail extracted the following IOCs",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -170,8 +166,17 @@
     "heuristics": [
       {
         "attack_ids": [],
-        "heur_id": 2,
-        "signatures": []
+        "heur_id": 3,
+        "signatures": [
+          "creates_blob"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "creates_object_url"
+        ]
       },
       {
         "attack_ids": [],
@@ -191,13 +196,6 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "prepare_network_request"
-        ]
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
           "save_to_file"
         ]
       },
@@ -209,15 +207,7 @@
         ]
       }
     ],
-    "tags": {
-      "network.dynamic.domain": [
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "attachment.zip"
-        }
-      ]
-    },
+    "tags": {},
     "temp_submission_data": {}
   }
 }

--- a/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
+++ b/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 531,
+    "score": 41,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,10,0,0,0,0,0,163,136,40,85,0,0,0,0,0,0,0,0,0,0,0,0,4,0,28,0,100,111,99,47,85,84,9...\n\t\t}var _0x3a5870=new Blob(_0x492071,{'type':_0x3262af})",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob((function() {????var Module, moduleOverrides, key, arguments_, thisProgram, quit_, ENVIRONM...\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -38,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction b64toBlob(_0x31a2b8,_0x3262af,_0x49150f){var _0x1f7950=a0_0x14b753,_0xedd820=atob(_0x31a2b8...\n\t\t}var blob=b64toBlob(text,'application/zip',0x200)",
+        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -48,19 +48,19 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "base64_decoding": 10
+            "creates_object_url": 10
           },
           "signatures": {
-            "base64_decoding": 1
+            "creates_object_url": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Base64Decoding",
+        "title_text": "Signature: CreatesObjectURL",
         "zeroize_on_tag_safe": false
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript writes data to disk\n\t\tmsSaveOrOpenBlob([object Blob], Document5934.zip)\n",
+        "body": "JavaScript attempts to sleep\n\t\twindow[5].setTimeout(function() {\n\n\t\twindow[5].setTimeout(function(){_0x2063A(_0x2033D)},2000)\n",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -70,19 +70,19 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "save_to_file": 10
+            "sleep": 10
           },
           "signatures": {
-            "save_to_file": 1
+            "sleep": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: SaveToFile",
+        "title_text": "Signature: Sleep",
         "zeroize_on_tag_safe": false
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript writes archive file to disk\n\t\tmsSaveOrOpenBlob([object Blob], Document5934.zip)\n",
+        "body": "JavaScript uses a suspicious process\n\t\tnew Worker(blob:nodedata:38202704-c774-4065-b37a-a5d7071ed68b)\n\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -90,22 +90,22 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 3,
-          "score": 500,
+          "score": 10,
           "score_map": {
-            "writes_archive": 500
+            "suspicious_process": 10
           },
           "signatures": {
-            "writes_archive": 1
+            "suspicious_process": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: WritesArchive",
+        "title_text": "Signature: SuspiciousProcess",
         "zeroize_on_tag_safe": false
       },
       {
         "auto_collapse": false,
-        "body": "\t\tAn encoded literal was found: AAAAAAAAAAAAAAAA\n\t\tObfuscated code was found that was obfuscated by: obfuscator.io",
-        "body_format": "TEXT",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"www.google-analytics.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://www.google-analytics.com/analytics.js'\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/analytics.js'\"}]",
+        "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
         "heuristic": {
@@ -117,15 +117,21 @@
           "signatures": {}
         },
         "tags": {
-          "file": {
-            "string": {
-              "extracted": [
-                "AAAAAAAAAAAAAAAA"
+          "network": {
+            "dynamic": {
+              "domain": [
+                "www.google-analytics.com"
+              ],
+              "uri": [
+                "https://www.google-analytics.com/analytics.js'"
+              ],
+              "uri_path": [
+                "/analytics.js'"
               ]
             }
           }
         },
-        "title_text": "JS-X-Ray IOCs Detected",
+        "title_text": "MalwareJail extracted the following IOCs",
         "zeroize_on_tag_safe": false
       }
     ]
@@ -133,16 +139,11 @@
   "files": {
     "extracted": [
       {
-        "name": "Document5934.zip",
-        "sha256": "05b8f8346baf3d7f50bc4315cd3d66e716916e716cc5ef3d3942dd7c2b71e933"
+        "name": "Blob[20]",
+        "sha256": "f5e236707a45e7af5461e4113d2bc60926142dfb9e83316553d00f0884cad923"
       }
     ],
-    "supplementary": [
-      {
-        "name": "temp_javascript.js",
-        "sha256": "fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237"
-      }
-    ]
+    "supplementary": []
   },
   "results": {
     "heuristics": [
@@ -162,30 +163,44 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "base64_decoding"
+          "creates_object_url"
         ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "save_to_file"
+          "sleep"
         ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "writes_archive"
+          "suspicious_process"
         ]
       }
     ],
     "tags": {
-      "file.string.extracted": [
+      "network.dynamic.domain": [
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "AAAAAAAAAAAAAAAA"
+          "value": "www.google-analytics.com"
+        }
+      ],
+      "network.dynamic.uri": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://www.google-analytics.com/analytics.js'"
+        }
+      ],
+      "network.dynamic.uri_path": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/analytics.js'"
         }
       ]
     },

--- a/tests/results/fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237/result.json
+++ b/tests/results/fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 522,
+    "score": 531,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,10,0,0,0,0,0,163,136,40,85,0,0,0,0,0,0,0,0,0,0,0,0,4,0,28,0,100,111,99,47,85,84,9...\n\t\t}var _0x3a5870=new Blob(_0x492071,{'type':_0x3262af})",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_blob": 10
+          },
+          "signatures": {
+            "creates_blob": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesBlob",
         "zeroize_on_tag_safe": false
       },
       {
@@ -82,32 +104,6 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"document5934.zip\"}]",
-        "body_format": "TABLE",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 2,
-          "score": 1,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {
-          "network": {
-            "dynamic": {
-              "domain": [
-                "document5934.zip"
-              ]
-            }
-          }
-        },
-        "title_text": "MalwareJail extracted the following IOCs",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "\t\tAn encoded literal was found: AAAAAAAAAAAAAAAA\n\t\tObfuscated code was found that was obfuscated by: obfuscator.io",
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -152,8 +148,10 @@
       },
       {
         "attack_ids": [],
-        "heur_id": 2,
-        "signatures": []
+        "heur_id": 3,
+        "signatures": [
+          "creates_blob"
+        ]
       },
       {
         "attack_ids": [],
@@ -183,13 +181,6 @@
           "heur_id": 2,
           "signatures": [],
           "value": "AAAAAAAAAAAAAAAA"
-        }
-      ],
-      "network.dynamic.domain": [
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "document5934.zip"
         }
       ]
     },

--- a/tests/test_jsjaws.py
+++ b/tests/test_jsjaws.py
@@ -311,7 +311,7 @@ class TestJsJaws:
             jsjaws_class_instance.malware_jail_sandbox_env_dir, jsjaws_class_instance.malware_jail_sandbox_env_dump
         )
         root_dir = path.dirname(path.dirname(path.abspath(__file__)))
-        assert jsjaws_class_instance.path_to_jailme_js == path.join(root_dir, "tools/malwarejail/jailme.cjs")
+        assert jsjaws_class_instance.path_to_jailme_js == path.join(root_dir, "tools/malwarejail/jailme.js")
         assert jsjaws_class_instance.malware_jail_urls_json_path == path.join(
             jsjaws_class_instance.malware_jail_payload_extraction_dir, "urls.json"
         )

--- a/tools/malwarejail/env/browser.js
+++ b/tools/malwarejail/env/browser.js
@@ -374,6 +374,7 @@ Document.prototype.constructor = Document;
 Document.toString = Document.toJSON = () => { return "Document" }
 
 document = _proxy(new Document());
+document.currentScript = _script_name;
 
 // create a stylesheet element with the contents from the extracted CSS in the HTML
 try {

--- a/tools/malwarejail/env/wscript.js
+++ b/tools/malwarejail/env/wscript.js
@@ -2,15 +2,15 @@
     wscript.js - simulates WScript (Windows scripting host) environment
 */
 
-const { Blob } = require("node:buffer");
-const URL = require('url').URL;
+const { resolveObjectURL } = require('node:buffer');
+const { win32 } = require('path');
 
 util_log("Preparing sandbox to emulate WScript environment.");
 _wscript_saved_files = {};
 _wscript_urls = [];
 _wscript_wmis = [];
 _wscript_objects = [];
-_pw32 = require('path').win32;
+_pw32 = win32;
 
 const appendChild_base64_regex = new RegExp("data:(?:[^;]+;)+base64,(.*)");
 
@@ -43,36 +43,13 @@ gapi = function () {
     this.load = function () { };
 }
 
+// This object does not exist in Node so we have to create it
 File = function (sources, filename, options = undefined) {
-    util_log("File(" + sources + ", " + filename + ", " + options + ")")
-    if (options)
-        blob = new Blob(sources, options);
-    blob = new Blob(sources);
-    saveAs(blob, filename)
+    util_log("new File(" + sources + ", " + filename + ", " + options + ")")
+    options["filename"] = filename;
+    const blob = new Blob(sources, options);
+    // We don't need to write the contents to a _wscript_save_file because the Blob class already does that...
     return blob;
-}
-
-URL.createObjectURL = async function (content) {
-    util_log("URL.createObjectURL(" + content + ")")
-    if (content.constructor.name == "Blob") {
-        content = Buffer.from(await content.arrayBuffer());
-    }
-    const url_blob = document.createElement("url_blob");
-    url_blob.srcObject = content
-    return url_blob;
-}
-
-URL.revokeObjectURL = async function (src) {
-    util_log("URL.revokeObjectURL(" + src + ")");
-    if (src.constructor.name == "Promise") {
-        util_log("Revoking ObjectURL Promise");
-        src.then(function(result) {
-            _wscript_saved_files["url_blob"] = result.srcObject;
-        });
-    }
-    else {
-        _wscript_saved_files["url_blob"] = src.srcObject;
-    }
 }
 
 let Base64 = {
@@ -1677,7 +1654,12 @@ XMLHttpRequest = function () {
     }
     this.open = function (m, u, a) {
         u = u.replace(/\r|\n/g, "");
-        util_log(this._name + ".open(" + m + "," + u + "," + a + ")");
+        util_log(this._name + _truncateOutput((".open(" + m + "," + u + "," + a + ")")));
+        match = u.match(appendChild_base64_regex);
+        if (match) {
+            util_log("Base64 match, decoding...");
+            _wscript_saved_files[this._name] = Buffer.from(match[1], 'base64');
+        }
         this.method = m;
         this.url = u;
         switch (("" + a).toLowerCase()) {
@@ -2200,4 +2182,63 @@ ga = function () {
 
 XPathResult = function () {
     return XPathResult;
+}
+
+// These constructors override the original class via aliasing.
+Blob = function() {
+    const _id = ++_object_id;
+    util_log("new Blob(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    const blob_sources = arguments[0]
+    const blob_options = arguments[1]
+    var blob_filename = "Blob[" + _id + "]";
+    if ("filename" in blob_options) {
+        blob_filename = blob_options["filename"]
+        delete blob_options["filename"]
+    }
+    const blob = new BlobAlias(sources=blob_sources, options=blob_options)
+    blob.arrayBuffer().then(function(result) {
+        _wscript_saved_files[blob_filename] = Buffer.from(result);
+    })
+    return blob
+}
+
+URL = function() {
+    util_log("new URL(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    return new URLAlias(arguments)
+}
+
+URL.createObjectURL = function () {
+    const _id = ++_object_id;
+    util_log("URL.createObjectURL(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    const blob = arguments[0]
+    blob.arrayBuffer().then(function(result) {
+        _wscript_saved_files["ObjectURL[" + _id + "]"] = Buffer.from(result);
+    })
+    return URLAlias.createObjectURL(blob);
+}
+
+URL.revokeObjectURL = function () {
+    util_log("URL.revokeObjectURL(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"));
+    return URLAlias.revokeObjectURL(arguments);
+}
+
+Worker = function() {
+    const _id = ++_object_id;
+    util_log("new Worker(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    var file_path = arguments[0]
+    if (file_path.slice(0, 5) === "blob:") {
+        // Worker expects a file path, not a Blob ID
+        // Therefore write the blob content to disk
+        file_name = "Blob[" + _id + "]";
+        file_path = _save_files + "/" + file_name;
+        const blob = resolveObjectURL(arguments[0])
+        blob.arrayBuffer().then(function(result) {
+            content = Buffer.from(result)
+            fs.writeFile(filename=file_path, data=content, function (err) {
+                if (err) return util_log(err)
+            });
+        });
+
+    }
+    return new WorkerAlias(file_path)
 }

--- a/tools/malwarejail/jailme.js
+++ b/tools/malwarejail/jailme.js
@@ -1,8 +1,25 @@
-const util = require('node:util');
-require('log-timestamp');
-const vm = require('vm');
-require('./cycle.cjs');
-const minimist = require("minimist")
+import util from 'node:util';
+import 'log-timestamp';
+import vm from 'node:vm';
+import './cycle.cjs';
+import minimist from "minimist";
+import path from 'path';
+import fs from "fs";
+import { createHash } from 'node:crypto';
+
+// WScript.js imports
+import { Blob as BlobAlias } from "node:buffer";
+import { URL as URLAlias } from "node:url";
+import { Worker as WorkerAlias } from "node:worker_threads";
+
+// Basically, we are running CommonJS files in the vm.runincontext, so we cannot import
+// specific modules from libraries. BUT we want to be able to rename libraries so that
+// we can override their functionality. Therefore we need to import and rename libs in
+// this file since it is being run as an ECMAScript, and then the renamed libs will be
+// accessible in the context which is pass to vm.runincontext. We need to pass the
+// "require" found below so that the CommonJS files have access to the "require" method.
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
 
 process.on('uncaughtException', (err) => {
     console.log('!!! Uncaught Exception !!!');
@@ -205,6 +222,7 @@ var sandbox = {};
 sandbox.toLowerCase = function () {
     return "sandbox";
 }
+sandbox.__dirname = path.resolve();
 
 // too ambitious
 // var sandbox = _proxy({});
@@ -291,8 +309,13 @@ sandbox._browser_api = {
 }
 
 sandbox._stylesheet = config.stylesheet;
+sandbox._save_files = config.save_files;
 
-fs = require('fs');
+// These are required to support specific module aliasing
+sandbox.BlobAlias = BlobAlias;
+sandbox.URLAlias = URLAlias;
+sandbox.WorkerAlias = WorkerAlias;
+
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 let ctx = vm.createContext(sandbox);
@@ -391,10 +414,10 @@ sandbox.require = undefined;
 
 // Run the malware
 console.log("==> Executing malware file(s). =========================================");
-process.exitCode = run_in_ctx(config.malware_files, log_catch = config.logerrors) ? 0 : 1;
+process.exitCode = run_in_ctx(config.malware_files, config.logerrors) ? 0 : 1;
 sandbox._config = config;
 sandbox._arguments = process.argv.slice(2).join(" ");
-exiting = false;
+let exiting = false;
 
 var dump_sandbox = function () {
     var s2 = {};
@@ -408,6 +431,10 @@ var dump_sandbox = function () {
     s2.util_inspect = util.inspect;
     s2._escape = /\/|\\|%|:/gi;
     s2._f = {};
+    function sha256(content) {
+        return createHash('sha256').update(content).digest('hex')
+    }
+    s2.sha256 = sha256;
     let c = `var _f = function(t) {
         var out;
         out = JSON.stringify(JSON.decycle(sandbox), function(key, value) {
@@ -454,8 +481,48 @@ var dump_sandbox = function () {
 
         var name, p, fname;
         p = sandbox._wscript_saved_files;
+
+        // We want to look for unique saved files and only write the one to disk that doesn't have a generic name
+        var saved_file_hashes = {};
+        for (let key in p) {
+            saved_file_hashes[key] = sha256(p[key]);
+        }
+
+        var all_sha256s = Object.values(saved_file_hashes);
+        var all_file_names = Object.keys(saved_file_hashes);
+        var keys_to_remove = new Set();
+        // Go through each file name in the filename-hash object
+        for (let key in saved_file_hashes) {
+            var same_sha256s = [];
+            var sha256_to_find = saved_file_hashes[key];
+            // If the same hash is found more than once, we can remove one
+            for (let index in all_sha256s) {
+                sha256_value = all_sha256s[index]
+                if (sha256_to_find == sha256_value) same_sha256s.push(all_file_names[index]);
+            }
+            // We have more than one of the same hash, therefore we need to figure out which file to keep
+            if (same_sha256s.length > 1) {
+                var keys_to_remove_per_hash = [];
+                for (let file_name of same_sha256s) {
+                    // If the file name is generic and there is a non-generic name
+                    if (file_name.indexOf("Blob") >= 0 || file_name.indexOf("ObjectURL") >= 0) {
+                        keys_to_remove_per_hash.push(file_name)
+                    }
+                }
+                // If all names are generic, pop all except last
+                if (keys_to_remove_per_hash.length == same_sha256s.length) {
+                    for (let item of keys_to_remove_per_hash.slice(0, -1)) keys_to_remove.add(item)
+                }
+                // If at least one name is non-generic, pop all except that
+                else if (keys_to_remove_per_hash.length < same_sha256s.length) {
+                    for (let item of keys_to_remove_per_hash) keys_to_remove.add(item)
+                }
+            }
+        }
+
         for (let key in p) {
             if (p.hasOwnProperty(key)) {
+                if (keys_to_remove.has(key)) continue;
                 name = key.replace(_escape, "_");
                 fname = config.save_files + name;
                 util_log("Saving: " + fname);

--- a/tools/package.json
+++ b/tools/package.json
@@ -2,13 +2,13 @@
     "name": "malware-jail",
     "version": "0.18.0",
     "description": "Nodejs based Sandbox for malware analysis.",
-    "main": "malwarejail/jailme.cjs",
+    "main": "malwarejail/jailme.js",
     "author": {
         "name": "Hynek Petrak",
         "email": "hynek.petrak@gmail.com"
     },
     "bin": {
-        "jailme": "malwarejail/jailme.cjs"
+        "jailme": "malwarejail/jailme.js"
     },
     "engines": {
         "node": ">=6.0.0"


### PR DESCRIPTION
Partially addresses https://cccs.atlassian.net/browse/AL-2000

This PR adds the following:
- `Dockerfile`:
    - Updating the Node version to v19 from v18
- `jailme.cjs`:
    - Switching the use of jailme.cjs from CommonJS to ECMAScript by renaming to jailme.js. This allows for import aliasing as detailed in a comment added in jailme.js.
- `jsjaws.py`:
    - Changing the use of `jailme.cjs` to `jailme.js`
    - Adding a list of domains that are associated with False Positives raised from the MalwareJail output. These "domains" will be redacted from the output as to avoid their flagging.
- `blob_usage.py`:
    - Adding a signature `creates_blob` that looks for `Blob` or `File` objects being created in the JavaScript. This score can be adjusted in the future depending on the success rate.
    - Adding a signature `creates_object_url` that looks for `URL.createObjectURL` objects being created in the JavaScript. This score can be adjusted in the future depending on the success rate.
- `decode.py`:
    - The `b64blb` method was observed in some samples. Adding to the `base64_decoding` signature for detection.
- `network.py`:
    - The `URL.createObjectURL` method does not actually prepare a network request, but instead creates an object at a URL location, so removing it from the signature `prepare_network_request`.
- `save_to_file.py`:
    - Adding new File objects created in JavaScript to a list of save commands, so that the signatures that use this list can fire on this.
- `suspicious_process.py`:
    - Adding the use of new Worker objects to a list of suspicious processes. This essentially creates a Thread, so we could split this into a new signature with a higher score if we recognize that this has a high success rate.
- `browser.py`:
    - Adding the `currentScript` property to the document object
- `wscript.py`:
    - Moving `require` calls to the top of the file
    - Refactoring the use of the `File` object so that the logging is better, and that we are not writing duplicated files to disk. Also pass "filename" to the `Blob` object so that this information is accessible to the more generic saving of a file in that constructor.
    - When a `XMLHTTPRequest` is opened and the URL is a file buffer, check if it is base64 and if so, decode and write to disk.
    - Create a `Blob` constructor which allows us to extend the original Blob class functionality, such as using "filename" when writing to disk and logging its use.
    - Create a `URL` constructor which allows us to extend the original URL class functionality, such as logging its use.
    - Refactoring the `URL.createObjectURL` method to improve logging, the writing of blobs to disk, and returning the original URL.createObjectURL.
    - Refactoring the `URL.revokeObjectURL` method to improve logging and returning the original URL.revokeObjectURL.
    - Create a `Worker` constructor which allows us to extend the original Worker class functionality, such as logging its use and handling blob IDs by writing them to disk.

That is all!