### PR TITLE
Adding support for combining embedded scripts and js, and other browser env variables

### DIFF
--- a/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
+++ b/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\tfunction reverse(s)\\x0d\n\t\tdocument.getElementById(\"preview\").src = reverse(viewer)",
+        "body": "JavaScript uses a commonly-seen method for de-obfuscating a string\n\t\tfunction reverse(s)\n\t\tdocument.getElementById(\"preview\").src = reverse(viewer)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/results/40c70ac063d55e6fa83fd4fcb80f079b6a30e1cc1d91e030c4c8347ba3d978de/result.json
+++ b/tests/results/40c70ac063d55e6fa83fd4fcb80f079b6a30e1cc1d91e030c4c8347ba3d978de/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 510,
+    "score": 1010,
     "sections": [
       {
         "auto_collapse": false,
@@ -46,7 +46,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 4,
-          "score": 500,
+          "score": 1000,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/8296c6f73683a7bb1c10825312c3e6201940cc2b333ee14f641056d98391ca45/result.json
+++ b/tests/results/8296c6f73683a7bb1c10825312c3e6201940cc2b333ee14f641056d98391ca45/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1,
+    "score": 11,
     "sections": [
       {
         "auto_collapse": false,
@@ -13,7 +13,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 6,
-          "score": 0,
+          "score": 10,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 10,
+    "score": 20,
     "sections": [
       {
         "auto_collapse": false,
@@ -13,7 +13,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 7,
-          "score": 0,
+          "score": 10,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 10,
+    "score": 20,
     "sections": [
       {
         "auto_collapse": false,
@@ -13,7 +13,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 7,
-          "score": 0,
+          "score": 10,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
+++ b/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 11,
+    "score": 21,
     "sections": [
       {
         "auto_collapse": false,
@@ -46,7 +46,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 6,
-          "score": 0,
+          "score": 10,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
+++ b/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 11,
+    "score": 551,
     "sections": [
       {
         "auto_collapse": false,
@@ -13,7 +13,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 7,
-          "score": 0,
+          "score": 10,
           "score_map": {},
           "signatures": {}
         },
@@ -34,7 +34,51 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t_0x1f8499=atob(_0x1f8499)",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(129,235, [object Object])\n\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob], [object Object])\n\n\t\t}return new Blob(_0x1936d3,{'type':_0x39e099(0x12c)})\n\t\t}let _0x298ed1=new File([_0x15710a],_0x255887(0x11d),{'type':_0x255887(0x12c)}),_0x3635d0=URL['creat...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_blob": 10
+          },
+          "signatures": {
+            "creates_blob": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesBlob",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_object_url": 10
+          },
+          "signatures": {
+            "creates_object_url": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesObjectURL",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tfunction b64toBlob(_0x390b80,_0x699e80){var _0x39e099=a0_0x3e7c,_0x1936d3=[],_0x5e2f86=atob(_0x390b8...\n\t\tvar _0x362cf0=_0xa80909[_0x1de451(0x136)],_0x46e8a=b64toBlob(_0x362cf0,0x200)\n\t\t_0x1f8499=atob(_0x1f8499)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -52,6 +96,50 @@
         },
         "tags": {},
         "title_text": "Signature: Base64Decoding",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript writes data to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\t}let _0x298ed1=new File([_0x15710a],_0x255887(0x11d),{'type':_0x255887(0x12c)}),_0x3635d0=URL['creat...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "save_to_file": 10
+          },
+          "signatures": {
+            "save_to_file": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: SaveToFile",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript writes archive file to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 500,
+          "score_map": {
+            "writes_archive": 500
+          },
+          "signatures": {
+            "writes_archive": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: WritesArchive",
         "zeroize_on_tag_safe": false
       },
       {
@@ -87,16 +175,20 @@
       {
         "name": "document_writes.html",
         "sha256": "7d7998cbcca611e08584b4872ff6ebda1c893dca1eb77c799e0fbccb62d89929"
+      },
+      {
+        "name": "attachment.zip",
+        "sha256": "db1dd90124ebd28a35e591dff072f3bd1429cf4092b9e850d3e6ee879457a954"
       }
     ],
     "supplementary": [
       {
-        "name": "temp_css.css",
-        "sha256": "965cce5ade224dd7e99f0fcd751202d236782be8b30504cabf443fc6bac191dc"
+        "name": "temp_javascript.js",
+        "sha256": "76b6330fa9bbb800bfca5e392adc99dc8fd3e80c55c6a88eac8cbe62b53cdf48"
       },
       {
-        "name": "temp_javascript.js",
-        "sha256": "f0e94a3a980b577ebd5f02d9d12d1dac5f6cadc59e9b73d30543d0fe540132a6"
+        "name": "temp_css.css",
+        "sha256": "965cce5ade224dd7e99f0fcd751202d236782be8b30504cabf443fc6bac191dc"
       }
     ]
   },
@@ -111,7 +203,35 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
+          "creates_blob"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "creates_object_url"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
           "base64_decoding"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "save_to_file"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "writes_archive"
         ]
       },
       {

--- a/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
+++ b/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 531,
+    "score": 1031,
     "sections": [
       {
         "auto_collapse": false,
@@ -90,7 +90,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 4,
-          "score": 500,
+          "score": 1000,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,20,0,1,0,8,0,234,145,70,85,152,108,183,42,144,114,3,0,0,248,6,0,16,0,0,0,79,118,1...\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob],[object Object])\n\n\t\t\t\t\t\tvar blob = new Blob(byteArrays, {type: \"application/zip\"})\n\t\t\t\t\t\tlet file = new File([blob], \"attachment.zip\", {type: \"application/zip\"})",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,20,0,1,0,8,0,234,145,70,85,152,108,183,42,144,114,3,0,0,248,6,0,16,0,0,0,79,118,1...\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob], [object Object])\n\n\t\t\t\t\t\tvar blob = new Blob(byteArrays, {type: \"application/zip\"})\n\t\t\t\t\t\tlet file = new File([blob], \"attachment.zip\", {type: \"application/zip\"})",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
+++ b/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 530,
+    "score": 1030,
     "sections": [
       {
         "auto_collapse": false,
@@ -90,7 +90,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 4,
-          "score": 500,
+          "score": 1000,
           "score_map": {},
           "signatures": {}
         },

--- a/tools/malwarejail/env/browser.js
+++ b/tools/malwarejail/env/browser.js
@@ -21,6 +21,7 @@ location = _proxy({
         util_log(this._name + ".replace(" + n + ")");
         this._props["href"] = n;
     },
+    // https://developer.mozilla.org/en-US/docs/Web/API/Location/assign
     assign: async function (n) {
         util_log(this._name + ".assign(" + n + ")");
         // In our sample, it is a promise
@@ -72,6 +73,8 @@ window = _proxy(new function () {
     //    _defineProperty(this, k, this._props);
     //}
     this.eval = eval;
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/parent
+    this.parent = this;
     this.settimeout = function () {
         util_log(this._name + ".setTimeout(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
         _setTimeout_calls[_setTimeout_calls.length] = arguments[0].toString();
@@ -153,9 +156,22 @@ window = _proxy(new function () {
     this.frames = function () {
         this.odbFrame = "";
     }
-    this.addEventListener = function (n) {
-        util_log(this._name + ".addEventListener(" + n + ")")
+    this.addEventListener = function () {
+        const type = arguments[0];
+        const listener = arguments[1];
+        this.document.addEventListener(type, listener);
     }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+    this.postMessage = function() {
+        const message = arguments[0];
+        const targetOrigin = arguments[1];
+        util_log(this._name + ".postMessage(" + _truncateOutput(message) + ", " + targetOrigin + ")");
+        if (this.document._events.length == 1) {
+            util_log("Setting the data of Event[" + document._events[0]._id + "]")
+            this.document._events[0].data = message;
+        }
+    }
+    this._events = [];
 });
 
 window.toString = () => { return "window" }
@@ -186,6 +202,7 @@ setInterval = window.setInterval.bind(window);
 clearInterval = window.clearInterval.bind(window);
 clearTimeout = window.clearInterval.bind(window);
 addEventListener = window.addEventListener;
+parent = window.parent;
 
 navigator = window;
 
@@ -194,6 +211,7 @@ Document = _proxy(function () {
     this._name = "document[" + this.id + "]";
     this._content = "";
     this._elements = [];
+    this._events = [];
     this.getelementsbytagname = function (n) {
         let ret = []
         util_log(this._name + ".getElementsByTagName(" + n + ")");
@@ -352,13 +370,26 @@ Document = _proxy(function () {
     this.readyState = function (n) {
         util_log("readyState(" + n + ")");
     }
-    this.addEventListener = function () {
-        util_log(this._name + ".addEventListener(" + Array.prototype.slice.call(arguments, 0) + ")")
-        for (i = 0; i < arguments.length; i++) {
-            let e = arguments[i];
-            if (typeof(e) === "function") {
-                e();
+    // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+    this.addEventListener = function (type, listener) {
+        if (listener.constructor.name === "Function") {
+            var function_name = listener.prototype.name;
+            if (function_name === undefined) {
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+                function_name = "anonymous";
             }
+            util_log(this._name + ".addEventListener(" + type + ", " + function_name + ")")
+            var e = null;
+            if (this._events.length == 1) {
+                e = this._events[0]
+            } else {
+                e = new Event(type);
+                this._events.push(e);
+            }
+            util_log("Running function " + function_name + "(" + e + ")");
+            listener(e);
+        } else {
+            util_log(this._name + ".addEventListener(" + type + ", " + listener + ")")
         }
     }
     this.attachEvent = function (n) {
@@ -428,3 +459,12 @@ let Image = function (w, h) {
 }
 Image.prototype = Object.create(Element.prototype);
 Image.prototype.constructor = Image;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Event
+Event = function() {
+    this._id = _object_id++;
+    this.origin = "null";
+    this.data = "get";
+    this.source = window;
+    util_log("new Event(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+};

--- a/tools/malwarejail/env/wscript.js
+++ b/tools/malwarejail/env/wscript.js
@@ -2186,9 +2186,9 @@ XPathResult = function () {
 // These constructors override the original class via aliasing.
 Blob = function() {
     const _id = _object_id++;
-    util_log("new Blob(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
     const blob_sources = arguments[0]
     const blob_options = arguments[1]
+    util_log("new Blob(" + _truncateOutput(blob_sources) + ", " + blob_options + ")");
     var blob_filename = "Blob[" + _id + "]";
     if ("filename" in blob_options) {
         blob_filename = blob_options["filename"]


### PR DESCRIPTION
Partially addresses https://cccs.atlassian.net/browse/AL-2006

This PR addresses the following:
- Regenerated results with the updated scores for heuristics from PR https://github.com/CybercentreCanada/assemblyline-service-jsjaws/pull/141
- Refactored the extraction of components using BeautifulSoup such that we can capture JavaScript from HTML element sources and aggregate them with JavaScript found directly in the HTML. This is a technique used by https://www.virustotal.com/gui/file/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799 where the HTML page consisted of multiple `script` elements plus an `embed` element whose source was a base64-encoded `image/svg` file which contained more JavaScript. So with this refactor we are able to grab all of that JavaScript and put it into the same file for analysis.
- Added functions to `browser.js` to facilitate the execution of the sample mentioned above, specifically the capability to handle window events.