### PR TITLE
In summary, added the capability to handle phishing html pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ access to the Internet, then we can fetch the actual jQuery library and compare 
 difference between them and then extracting the difference (aka malicious code). If the service Docker container
 does not have Internet access, then please set the `docker_config` value of `allow_internet_access` to `False` in the
 `service_manifest.yml`.
+
+## Assemblyline System Safelist
+### JsJaws-specific safelisted items
+The file at `al_config/system_safelist.yaml` contains suggested safelisted values that can be added to the Assemblyline system safelist
+either by copy-and-pasting directly to the text editor on the page `https://<Assemblyline Instance>/admin/tag_safelist` or through the [Assemblyline Client](https://github.com/CybercentreCanada/assemblyline_client).

--- a/al_config/system_safelist.yaml
+++ b/al_config/system_safelist.yaml
@@ -1,0 +1,19 @@
+regex:
+  network.dynamic.domain:
+  # GoogleAPIs
+  - .*\.googleapis\.com$
+  # GStatic
+  - .*\.gstatic\.com$
+  # jsDelivr
+  - cdn\.jsdelivr\.net$
+  # WWW
+  - www\.w3\.org$
+  network.dynamic.uri:
+  # GoogleAPIs
+  - https?://.*\.googleapis\.com(?:$|/.*)
+  # GStatic
+  - https?://.*\.gstatic\.com(?:$|/.*)
+  # jsDelivr
+  - https?://cdn\.jsdelivr\.net(?:$|/.*)
+  # WWW
+  - https?://www\.w3\.org(?:$|/.*)

--- a/jsjaws.py
+++ b/jsjaws.py
@@ -16,6 +16,7 @@ from threading import Thread
 from time import time
 from tinycss2 import parse_stylesheet
 from typing import Any, Dict, List, Optional, Set, Tuple
+from yaml import safe_load as yaml_safe_load
 from yara import compile as yara_compile
 
 from assemblyline.common import forge
@@ -31,6 +32,7 @@ from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.dynamic_service_helper import (
     OntologyResults,
     extract_iocs_from_text_blob,
+    URL_REGEX,
 )
 from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.result import (
@@ -41,6 +43,7 @@ from assemblyline_v4_service.common.result import (
     ResultTextSection,
     TableRow,
 )
+from assemblyline_v4_service.common.safelist_helper import is_tag_safelisted
 
 import signatures
 from signatures.abstracts import Signature
@@ -59,7 +62,13 @@ COMBO_REGEX = (
 UNDERSCORE_REGEX = r"\/\/     Underscore.js ([\d\.]+)\n"
 MALWARE_JAIL_TIME_STAMP = re.compile(r"\[(.+)\] ")
 APPENDCHILD_BASE64_REGEX = re.compile("data:(?:[^;]+;)+base64,(.*)")
-GETELEMENTBYID_REGEX = re.compile("document\.(?:getElementById|querySelector)\([\"\']([a-zA-Z0-9_#]+)[\"\']\)")
+DIVIDING_COMMENT = "// This comment was created by JsJaws"
+SAFELIST_PATH = "al_config/system_safelist.yaml"
+ELEMENT_INDEX_REGEX = re.compile(b"const element(\d+)_jsjaws = ")
+SAFELISTED_ATTRS_TO_POP = {
+    "link": ["href"],
+    "svg": ["xmlns"],
+}
 
 # Signature Constants
 TRANSLATED_SCORE = {
@@ -114,9 +123,13 @@ class JsJaws(ServiceBase):
         self.cleaned_with_synchrony_path: Optional[str] = None
         self.stdout_limit: Optional[int] = None
         self.identify = forge.get_identify(use_cache=environ.get("PRIVILEGED", "false").lower() == "true")
+        self.safelist = Optional[Dict[str, List[str]]]
         self.log.debug("JsJaws service initialized")
 
     def start(self) -> None:
+        with open(SAFELIST_PATH, "r") as f:
+            self.safelist = yaml_safe_load(f)
+
         self.log.debug("JsJaws service started")
         self.stdout_limit = self.config.get("total_stdout_limit", STDOUT_LIMIT)
 
@@ -283,7 +296,7 @@ class JsJaws(ServiceBase):
         if log_errors:
             malware_jail_args.append("--logerrors")
 
-        jsxray_args = ["node", self.path_to_jsxray]
+        jsxray_args = ["node", self.path_to_jsxray, f"{DIVIDING_COMMENT}\n"]
 
         synchrony_args = [self.path_to_synchrony, "deobfuscate", "--output", self.cleaned_with_synchrony_path]
 
@@ -291,7 +304,15 @@ class JsJaws(ServiceBase):
         boxjs_args.append(file_path)
         malware_jail_args.append(file_path)
         jsxray_args.append(file_path)
-        synchrony_args.append(file_path)
+
+        # If there is a DIVIDING_COMMENT in the script to run, extract the actual script and send that to Synchrony
+        if f"{DIVIDING_COMMENT}\n".encode() in file_content:
+            _, actual_script = file_content.split(f"{DIVIDING_COMMENT}\n".encode())
+            with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as t:
+                t.write(actual_script)
+                synchrony_args.append(t.name)
+        else:
+            synchrony_args.append(file_path)
 
         tool_threads: List[Thread] = []
         responses: Dict[str, List[str]] = {}
@@ -402,21 +423,44 @@ class JsJaws(ServiceBase):
         aggregated_script.write(encoded_script + b"\n")
         return file_content, aggregated_script
 
-    def extract_using_soup(self, request: ServiceRequest, file_content: bytes) -> Tuple[str, bytes, Optional[str]]:
+    def insert_content(self, content: str, file_content: bytes, aggregated_script: Optional[tempfile.NamedTemporaryFile]) -> Tuple[bytes, tempfile.NamedTemporaryFile]:
+        """
+        This method inserts contents above the dividing comment line in a NamedTemporaryFile
+        :param content: content to be inserted
+        :param file_content: The file content of the NamedTemporaryFile
+        :param aggregated_script: The NamedTemporaryFile object
+        :return: A tuple of the file contents of the NamedTemporaryFile object and the NamedTemporaryFile object
+        """
+        encoded_script = content.encode()
+        if aggregated_script is None:
+            aggregated_script = tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb")
+        # Get the point in the file contents where the divider exists
+        if file_content != b"":
+            index_of_divider = file_content.index(DIVIDING_COMMENT.encode())
+            # Find the beginning of the file
+            aggregated_script.seek(0, 0)
+            # Insert the encoded script before the divider
+            file_content = file_content[:index_of_divider] + encoded_script + b"\n" + file_content[index_of_divider:]
+            aggregated_script.write(file_content)
+            # Find the end of the file
+            aggregated_script.seek(0, 2)
+        return file_content, aggregated_script
+
+    def extract_using_soup(self, request: ServiceRequest, initial_file_content: bytes) -> Tuple[str, bytes, Optional[str]]:
         """
         This method extracts elements from an HTML file using the BeautifulSoup library
         :param request: The ServiceRequest object
-        :param file_content: The contents of the file to be read
+        :param initial_file_content: The contents of the initial file to be read
         :return: A tuple of the JavaScript file name that was written, the contents of the file that was written, and the name of the CSS file that was written
         """
-        soup = BeautifulSoup(file_content, features="html5lib")
+        soup = BeautifulSoup(initial_file_content, features="html5lib")
 
         aggregated_js_script = None
         js_content = b""
         js_script_name = None
         css_script_name = None
 
-        aggregated_js_script, file_content = self._extract_js_using_soup(soup, aggregated_js_script, js_content)
+        aggregated_js_script, js_content = self._extract_js_using_soup(soup, aggregated_js_script, js_content)
 
         if request.file_type in ["code/html", "code/hta"]:
             aggregated_js_script, js_content = self._extract_embeds_using_soup(soup, request, aggregated_js_script, js_content)
@@ -428,7 +472,9 @@ class JsJaws(ServiceBase):
             request.add_supplementary(aggregated_js_script.name, "temp_javascript.js", "Extracted JavaScript")
             js_script_name = aggregated_js_script.name
 
-        return js_script_name, file_content, css_script_name
+        if js_content != b"":
+            return js_script_name, js_content, css_script_name
+        return js_script_name, initial_file_content, css_script_name
 
     def _extract_embeds_using_soup(self, soup: BeautifulSoup, request: ServiceRequest, aggregated_js_script: Optional[tempfile.NamedTemporaryFile], js_content: bytes = b"") -> Tuple[Optional[tempfile.NamedTemporaryFile], Optional[bytes]]:
         """
@@ -455,23 +501,94 @@ class JsJaws(ServiceBase):
                 self.log.debug(f"Extracting decoded embed tag source {embed_path}")
                 request.add_extracted(embed_path, get_sha256_for_file(embed_path), "Base64-decoded Embed Tag Source")
 
-                # We also want to aggregate Javscript scripts
+                # We also want to aggregate Javscript scripts, but prior to the DIVIDING_COMMENT break, if it exists
                 file_info = self.identify.ident(embedded_file_content, len(embedded_file_content), embed_path)
                 if file_info["type"] in ["code/html", "code/hta", "image/svg"]:
                     soup = BeautifulSoup(embedded_file_content, features="html5lib")
-                    aggregated_js_script, js_content = self._extract_js_using_soup(soup, aggregated_js_script, js_content)
+                    aggregated_js_script, js_content = self._extract_js_using_soup(soup, aggregated_js_script, js_content, insert_above_divider=True)
 
         return aggregated_js_script, js_content
 
-    def _extract_js_using_soup(self, soup: BeautifulSoup, aggregated_js_script: Optional[tempfile.NamedTemporaryFile] = None, js_content: bytes = b"") -> Tuple[Optional[tempfile.NamedTemporaryFile], Optional[bytes]]:
+    def _extract_js_using_soup(self, soup: BeautifulSoup, aggregated_js_script: Optional[tempfile.NamedTemporaryFile] = None, js_content: bytes = b"", insert_above_divider: bool = False) -> Tuple[Optional[tempfile.NamedTemporaryFile], Optional[bytes]]:
         """
         This method extracts JavaScript from BeautifulSoup enumeration
         :param soup: The BeautifulSoup object
         :param aggregated_js_script: The NamedTemporaryFile object
         :param js_content: The file content of the NamedTemporaryFile
+        :param insert_above_divider: A flag indicating if we have more code that is going to be programmatically created
         :return: A tuple of the JavaScript file that was written and the contents of the file that was written
         """
         scripts = soup.findAll("script")
+
+        # Create most HTML elements with JavaScript
+        elements = soup.findAll()
+        for index, element in enumerate(elements):
+            # We don't want these elements dynamically created
+            if element.name in ["html", "head", "meta", "style", "body", "script"]:
+                continue
+
+            # If an element has an attribute that is safelisted, don't include it when we create the element
+            if element.name in SAFELISTED_ATTRS_TO_POP:
+                for attr in SAFELISTED_ATTRS_TO_POP[element.name]:
+                    if is_tag_safelisted(element.attrs.get(attr), ["network.dynamic.domain", "network.dynamic.uri"], self.safelist):
+                        element.attrs.pop(attr)
+
+            # To avoid duplicate of embed extraction, check if embed matches criteria used in the extract_embeds_using_soup method
+            if element.name == "embed":
+                src = element.attrs.get("src")
+                if src and re.match(APPENDCHILD_BASE64_REGEX, src):
+                    continue
+
+            # If we are inserting an element above the divider, we should grab the last index used and add to that...
+            # Find last occurrence of "element{}_jsjaws ="" in the js_content
+            if insert_above_divider:
+                matches = re.findall(ELEMENT_INDEX_REGEX, js_content)
+                last_used_index = int(matches[-1])
+                idx = index + last_used_index + 1
+            else:
+                idx = index
+
+            # If the element does not have an ID, mock one
+            element_id = element.attrs.get("id", f"element{idx}")
+            random_element_varname = f"{element_id.lower()}_jsjaws"
+            # We cannot trust the text value of these elements, since it contains all nested items within it...
+            if element.name in ["div", "p", "svg"]:
+                # If the element contains a script child, and the element's string is the same as the script child's, set value to None
+                if element.next.name == "script" and element.string == element.next.string:
+                    element_value = None
+                elif element.string is not None:
+                    element_value = element.string.strip().replace("\n", "")
+                else:
+                    element_value = None
+            else:
+                element_value = element.text.strip().replace("\n", "")
+            # Create an element and set the innertext
+            # NOTE: There is a regex ELEMENT_INDEX_REGEX that depends on this variable value
+            create_element_script = f"const {random_element_varname} = document.createElement(\"{element.name}\");\n" \
+                                    f"{random_element_varname}.setAttribute(\"id\", \"{element_id}\");\n" \
+                                    f"document.body.appendChild({random_element_varname});\n"
+            # Only set innertext field if there is a value to set it to
+            if element_value:
+                # Escape double quotes since we are wrapping the value in double quotes
+                if '"' in element_value:
+                    element_value = element_value.replace('"', '\\"')
+                create_element_script += f"{random_element_varname}.innertext = \"{element_value}\";\n"
+            for attr_id, attr_val in element.attrs.items():
+                if attr_id != "id":
+                    create_element_script += f"{random_element_varname}.setAttribute(\"{attr_id}\", \"{attr_val}\");\n"
+
+            if insert_above_divider:
+                js_content, aggregated_js_script = self.insert_content(create_element_script, js_content, aggregated_js_script)
+            else:
+                js_content, aggregated_js_script = self.append_content(create_element_script, js_content, aggregated_js_script)
+
+        if not insert_above_divider:
+            # Add a break that is obvious for JS-X-Ray to differentiate
+            js_content, aggregated_js_script = self.append_content(DIVIDING_COMMENT, js_content, aggregated_js_script)
+
+        # We need this flag since we are now creating most HTML elements dynamically,
+        # and there is a chance that an HTML file has no JavaScript to be run.
+        is_script_body = False
         for script in scripts:
             # Make sure there is actually a body to the script
             body = script.string
@@ -482,43 +599,25 @@ class JsJaws(ServiceBase):
                 continue
 
             if script.get("type", "").lower() in ["", "text/javascript"]:
-                # Hunting for elements to programmatically create
-                get_element_by_id_match = re.findall(GETELEMENTBYID_REGEX, body)
-                for element_id in get_element_by_id_match:
-                    if element_id.startswith("#"):
-                        element_id = element_id.replace("#", "", 1)
-                    element = soup.find(id=element_id)
-                    if not element:
-                        continue
-
-                    # Create an element and set the text
-                    random_element_varname = f"{element_id.lower()}_jsjaws"
-                    element_value = element.text.strip().replace("\n", "")
-                    create_element_script = f"const {random_element_varname} = document.createElement(\"div\");\n" \
-                                            f"{random_element_varname}.setAttribute(\"id\", \"{element_id}\");\n" \
-                                            f"document.body.appendChild({random_element_varname});\n" \
-                                            f"{random_element_varname}.text = \"{element_value}\";\n"
-                    for attr_id, attr_val in element.attrs.items():
-                        if attr_id != "id":
-                            create_element_script += f"{random_element_varname}.setAttribute(\"{attr_id}\", \"{attr_val}\");\n"
-                    js_content, aggregated_js_script = self.append_content(create_element_script, js_content, aggregated_js_script)
-
                 # If there is no "type" attribute specified in a script element, then the default assumption is
                 # that the body of the element is Javascript
+                is_script_body = True
                 js_content, aggregated_js_script = self.append_content(body, js_content, aggregated_js_script)
 
         if soup.body:
             for line in soup.body.get_attribute_list("onpageshow"):
                 if line:
+                    is_script_body = True
                     js_content, aggregated_js_script = self.append_content(line, js_content, aggregated_js_script)
-
-        if aggregated_js_script is None:
-            return aggregated_js_script, js_content
 
         if soup.body:
             for onload in soup.body.get_attribute_list("onload"):
                 if onload:
+                    is_script_body = True
                     js_content, aggregated_js_script = self.append_content(onload, js_content, aggregated_js_script)
+
+        if aggregated_js_script is None or not is_script_body:
+            return None, js_content
 
         return aggregated_js_script, js_content
 
@@ -1200,7 +1299,7 @@ class JsJaws(ServiceBase):
                 for fp_domain in FP_DOMAINS:
                     log_line = log_line.replace(fp_domain, "<replaced>")
 
-            extract_iocs_from_text_blob(log_line, malware_jail_res_sec)
+            extract_iocs_from_text_blob(log_line, malware_jail_res_sec, enforce_domain_char_max=True)
 
             if log_line.startswith("Exception occurred in "):
                 exception_lines = []
@@ -1215,32 +1314,41 @@ class JsJaws(ServiceBase):
                 else:
                     self.log.warning("Exception occurred in MalwareJail\n" + "\n".join(exception_lines[::-1]))
             if log_line.startswith("location.href = "):
-                # We need to recover the non-truncated content from the sandbox_dump.json file
-                with open(self.malware_jail_sandbox_env_dump_path, "r") as f:
-                    data = load(f)
-                    location_href = data["location"]["_props"]["href"]
-                    if location_href.lower().startswith("ms-msdt:"):
-                        heur = Heuristic(5)
-                        res = ResultTextSection(heur.name, heuristic=heur, parent=request.result)
 
-                        # Try to only recover the msdt command's powershell for the extracted file
-                        # If we can't, write the whole command
-                        try:
-                            encoded_content = self.parse_msdt_powershell(location_href).encode()
-                        except ValueError:
-                            encoded_content = location_href.encode()
+                # If the sandbox_dump.json file was not created for some reason, pull the location.href out (it may be truncated, but desperate times call for desperate measures)
+                location_href = ""
+                if not path.exists(self.malware_jail_sandbox_env_dump_path):
+                    matches = re.findall(URL_REGEX, log_line)
+                    if matches and len(matches) == 2:
+                        location_href = matches[1]
+                else:
+                    # We need to recover the non-truncated content from the sandbox_dump.json file
+                    with open(self.malware_jail_sandbox_env_dump_path, "r") as f:
+                        data = load(f)
+                        location_href = data["location"]["_props"]["href"]
+
+                if location_href.lower().startswith("ms-msdt:"):
+                    heur = Heuristic(5)
+                    res = ResultTextSection(heur.name, heuristic=heur, parent=request.result)
+
+                    # Try to only recover the msdt command's powershell for the extracted file
+                    # If we can't, write the whole command
+                    try:
+                        encoded_content = self.parse_msdt_powershell(location_href).encode()
+                    except ValueError:
+                        encoded_content = location_href.encode()
 
                         with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False) as out:
                             out.write(encoded_content)
-                        request.add_extracted(
-                            out.name, sha256(encoded_content).hexdigest(), "Redirection location"
-                        )
-                    else:
-                        heur = Heuristic(6)
-                        res = ResultTextSection(heur.name, heuristic=heur, parent=request.result)
-                        res.add_tag("network.static.uri", location_href)
-                    res.add_line("Redirection to:")
-                    res.add_line(location_href)
+                    request.add_extracted(
+                        out.name, sha256(encoded_content).hexdigest(), "Redirection location"
+                    )
+                else:
+                    heur = Heuristic(6)
+                    res = ResultTextSection(heur.name, heuristic=heur, parent=request.result)
+                    res.add_tag("network.static.uri", location_href)
+                res.add_line("Redirection to:")
+                res.add_line(location_href)
 
         if malware_jail_res_sec.body:
             malware_jail_res_sec.set_heuristic(2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4
 html5lib
 tinycss2
 yara-python
+PyYAML

--- a/signatures/network.py
+++ b/signatures/network.py
@@ -37,8 +37,22 @@ class AJAXNetworkRequest(Signature):
         super().__init__(
             heuristic_id=3,
             name="ajax_network_request",
-            description="JavaScript sends a network request via AJAX",
+            description="JavaScript sends a network request via AJAX and jQuery",
             indicators=["$.ajax("],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)
+
+
+class JQueryNetworkRequest(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="jquery_network_request",
+            description="JavaScript sends a network request via jQuery",
+            indicators=["$.post(", "$.getJSON("],
             severity=0
         )
 

--- a/tests/results/1b61b16dd4b7f6203d742b47411ca679f1f5734ed01534a37a126263f84396c0/result.json
+++ b/tests/results/1b61b16dd4b7f6203d742b47411ca679f1f5734ed01534a37a126263f84396c0/result.json
@@ -162,7 +162,7 @@
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "fdb599ee616fa643820cfaeb9afe561fe5915447ccc80f7d63d85573f0440237"
+        "sha256": "60036b577df967efacc994bb15ca34f31a11990c7231636362cd02008981ac2c"
       }
     ]
   },

--- a/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
+++ b/tests/results/1e98af662c337468274d2a20e1f5eb66645c8fff55269ee09fa9ba6e0733ce98/result.json
@@ -41,18 +41,18 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<embed>",
+        "name": "Element[25]<embed>",
         "sha256": "c9d18e2d8379ac4e6c8e24ca1215a3812f0cb6e81bb676b4858fac717b192640"
       }
     ],
     "supplementary": [
       {
-        "name": "temp_css.css",
-        "sha256": "7f1cd9bb980c4fcaefb23d5cb926814c1a99b12792311157d12d52cfc7630fe0"
+        "name": "temp_javascript.js",
+        "sha256": "433890ef5dc0f4b8af291eea912a2369550c177873052b53de79232fde994cae"
       },
       {
-        "name": "temp_javascript.js",
-        "sha256": "8b97607c6177b7b7b8cd0c8bab915c60ee922bcb4131759ee6c1eac31c975b95"
+        "name": "temp_css.css",
+        "sha256": "7f1cd9bb980c4fcaefb23d5cb926814c1a99b12792311157d12d52cfc7630fe0"
       }
     ]
   },

--- a/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
+++ b/tests/results/277bbc25876160e3dad99f00dc53c4c065d41cdc7b0ad2c430aa60d9e3ebfa3b/result.json
@@ -41,7 +41,7 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<div>",
+        "name": "Element[22]<embed>",
         "sha256": "2cbc2634efc72b2203b85dce2b488e393172388d09bdf4fdf25ca04e6f6513f8"
       }
     ],
@@ -52,7 +52,7 @@
       },
       {
         "name": "temp_javascript.js",
-        "sha256": "bfa311dc3cab0e2fb5bc09223b555993eeb8a44a8f0745990d3a1802569824d5"
+        "sha256": "c55ab616e9d01fa80f5ed2e07b69ef51e7b3880773659fa37fe15289575adbe4"
       }
     ]
   },

--- a/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
+++ b/tests/results/2b26cd43aee8e79e808add3cebaa4902731b529274ef697c5ff9486c71a91b4d/result.json
@@ -104,7 +104,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript appends a child object to the document and clicks it\n\t\tElement[13]<a>.click(undefined)\n\n\t\t        hWgcnjlRWVbB.click()",
+        "body": "JavaScript appends a child object to the document and clicks it\n\t\tElement[79]<a>.click(undefined)\n\n\t\t        hWgcnjlRWVbB.click()",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -129,14 +129,14 @@
   "files": {
     "extracted": [
       {
-        "name": "Blob[14]",
+        "name": "Blob[80]",
         "sha256": "d303c8ff0303b9f86867615e9e3d77323f9ba65c26d2856086bd3df4587fbf55"
       }
     ],
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "69fabb2c7195f5ff89d07b529a33d9297f28a13707db0135eddf967ee493b44f"
+        "sha256": "fc291124973434c930d0f66a3225b4e742be81d8f04483198a57c3aa56b1a2e8"
       }
     ]
   },

--- a/tests/results/7933c6d82685a75f0b2fc3f9fa4a5c2dc9406fb7d3ac0fb59308aab27415c0d4/result.json
+++ b/tests/results/7933c6d82685a75f0b2fc3f9fa4a5c2dc9406fb7d3ac0fb59308aab27415c0d4/result.json
@@ -40,7 +40,7 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[15]<embed>",
+        "name": "Element[25]<embed>",
         "sha256": "2823b855fd79efac8f598671e9ffbe9e0837e28dba7bafc77d0f9d36cbed13a8"
       }
     ],
@@ -51,7 +51,7 @@
       },
       {
         "name": "temp_javascript.js",
-        "sha256": "ecf7d22c29202631acfb725655baf3df6c677fcb0512996bffd11e1e57360db4"
+        "sha256": "3cd7de285ec1df9cf61b821222571248709d4ae33f8d7adfb51beddc8e5c2607"
       }
     ]
   },

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb/result.json
@@ -63,18 +63,18 @@
         "sha256": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa"
       },
       {
-        "name": "Element[13]<embed>",
+        "name": "Element[19]<embed>",
         "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
       }
     ],
     "supplementary": [
       {
-        "name": "temp_javascript.js",
-        "sha256": "66c02bb2c5f562b07c93e75a820da97de351f8e012b6033c48cec05e57589677"
-      },
-      {
         "name": "temp_css.css",
         "sha256": "9ae702f0ebdbe99d96c0270cfca6e0cc5fb69de7f6544a246e2a58fe7f478ce1"
+      },
+      {
+        "name": "temp_javascript.js",
+        "sha256": "a9af67e3bf8b37b023a70a95bcf6e0b1a3d7a18825f8c1de2a57ff21499a215d"
       }
     ]
   },

--- a/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
+++ b/tests/results/96d93ac91d1dd3bb94db752f5b365efbd83411a0bddd09dfec1b848983b097bb_append_passwords/result.json
@@ -63,18 +63,18 @@
         "sha256": "e126343a747e4e8748853097e97cf4f1e6f2e488eeb79745ab2514d2bf7acafa"
       },
       {
-        "name": "Element[13]<embed>",
+        "name": "Element[19]<embed>",
         "sha256": "f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f"
       }
     ],
     "supplementary": [
       {
-        "name": "temp_javascript.js",
-        "sha256": "66c02bb2c5f562b07c93e75a820da97de351f8e012b6033c48cec05e57589677"
-      },
-      {
         "name": "temp_css.css",
         "sha256": "9ae702f0ebdbe99d96c0270cfca6e0cc5fb69de7f6544a246e2a58fe7f478ce1"
+      },
+      {
+        "name": "temp_javascript.js",
+        "sha256": "a9af67e3bf8b37b023a70a95bcf6e0b1a3d7a18825f8c1de2a57ff21499a215d"
       }
     ]
   },

--- a/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
+++ b/tests/results/99deeffd3379798b33f3b8b4da55b52960dc113596004ee827f639a609cca753/result.json
@@ -73,14 +73,14 @@
   "files": {
     "extracted": [
       {
-        "name": "Element[14]<embed>",
+        "name": "Element[23]<embed>",
         "sha256": "99c0e03a256f95d1b7e7323ac0cfe359ed5c540596d3b8e26c5ba5731e62a264"
       }
     ],
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "68540121821703871fc7ad5e559af0aa43e33164a105ea47f189b3f58380db2e"
+        "sha256": "4e565f5545dc6296b2ed0cf6f7c85058ac50821605e382f5c1ff07b13c11c3d7"
       },
       {
         "name": "temp_css.css",

--- a/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
+++ b/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
@@ -101,7 +101,7 @@
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "fd2f5346f0d894a5490a5880c1769c8d0e566cfa3a6f8305c6a3dd5fde29ef9a"
+        "sha256": "d3165153bac461f0779452777fc69f2b4e5de614a8c828805df6e571efb5f030"
       }
     ]
   },

--- a/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
+++ b/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
@@ -34,7 +34,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,20,0,11,0,8,0,3,147,89,85,229,6,95,68,85,138,3,0,0,40,11,0,18,0,28,0,100,111,99,1...\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob], [object Object])\n",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob(80,75,3,4,20,0,11,0,8,0,3,147,89,85,229,6,95,68,85,138,3,0,0,40,11,0,18,0,28,0,100,111,99,1...\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\tnew Blob([object Blob], [object Object])\n\n\t\t}return new Blob(_0x1936d3,{'type':_0x39e099(0x12c)})\n\t\t}let _0x298ed1=new File([_0x15710a],_0x255887(0x11d),{'type':_0x255887(0x12c)}),_0x3635d0=URL['creat...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -78,7 +78,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t_0x1f8499=atob(_0x1f8499)",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\t_0x1f8499=atob(_0x1f8499)\n\t\tfunction b64toBlob(_0x390b80,_0x699e80){var _0x39e099=a0_0x3e7c,_0x1936d3=[],_0x5e2f86=atob(_0x390b8...\n\t\tvar _0x362cf0=_0xa80909[_0x1de451(0x136)],_0x46e8a=b64toBlob(_0x362cf0,0x200)",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -100,7 +100,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript writes data to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n",
+        "body": "JavaScript writes data to disk\n\t\tnew File([object Blob], attachment.zip, [object Object])\n\n\t\t}let _0x298ed1=new File([_0x15710a],_0x255887(0x11d),{'type':_0x255887(0x12c)}),_0x3635d0=URL['creat...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -205,12 +205,12 @@
     ],
     "supplementary": [
       {
-        "name": "temp_javascript.js",
-        "sha256": "79987630e7fd6e25212c1f696b66affcad36b46fb601360aaf8cf6999d015f38"
-      },
-      {
         "name": "temp_css.css",
         "sha256": "965cce5ade224dd7e99f0fcd751202d236782be8b30504cabf443fc6bac191dc"
+      },
+      {
+        "name": "temp_javascript.js",
+        "sha256": "add21b4780b502cf93737dac5f3d9c4c36c960e5d8e3229e00598e2a66cd11c5"
       }
     ]
   },

--- a/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
+++ b/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
@@ -60,7 +60,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"cdn.jsdelivr.net\"}, {\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk\"}]",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"domain\", \"ioc\": \"cdn.jsdelivr.net\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -76,12 +76,12 @@
           "network": {
             "dynamic": {
               "domain": [
-                "cdn.jsdelivr.net",
-                "folderdata021755.tk"
+                "folderdata021755.tk",
+                "cdn.jsdelivr.net"
               ],
               "uri": [
-                "https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css",
-                "https://folderdata021755.tk"
+                "https://folderdata021755.tk",
+                "https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"
               ],
               "uri_path": [
                 "/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"

--- a/tests/results/ef6b8c81e589828cdd3b94eb1ed26cdf0e3adf60cac8b3f360674fa0957c229c/result.json
+++ b/tests/results/ef6b8c81e589828cdd3b94eb1ed26cdf0e3adf60cac8b3f360674fa0957c229c/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript sends a network request via AJAX\n\t\t$.ajax({\"type\":\"GET\",\"url\":\"https://www.icodeps.com/jsapi.php\"})\n",
+        "body": "JavaScript sends a network request via AJAX and jQuery\n\t\t$.ajax({\"type\":\"GET\",\"url\":\"https://www.icodeps.com/jsapi.php\"})\n",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
+++ b/tests/results/f4f43bfabf8e410683a9ffaa7acd359fda0045b35d1eef7bd872ae2c4064382f/result.json
@@ -158,7 +158,7 @@
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "67c34aec1f9dc2ebddaa0503055066dbc00d6aa8c7973bba4258790cfd10c74a"
+        "sha256": "40e1a302e6a37e03664203cf3a3abda5577db7f13312ebb752e47121923e7c66"
       }
     ]
   },

--- a/tools/js-x-ray-run.js
+++ b/tools/js-x-ray-run.js
@@ -1,7 +1,18 @@
 import { runASTAnalysis } from "@nodesecure/js-x-ray";
 import { readFileSync } from "fs";
 
-var file_path = process.argv[2];
-const str = readFileSync(file_path, "utf-8");
-const { warnings } = runASTAnalysis(str);
+const dividing_comment = process.argv[2];
+const file_path = process.argv[3];
+
+const file_contents = readFileSync(file_path, "utf-8");
+
+// Splitting on an obvious differentiator from the code that dynamically creates elements and the original script
+const split_script = file_contents.split(dividing_comment)
+if (split_script.length == 2) {
+    var actual_script = split_script[1];
+} else {
+    var actual_script = split_script[0];
+}
+
+const { warnings } = runASTAnalysis(actual_script);
 console.log(JSON.stringify({"warnings": warnings}));

--- a/tools/malwarejail/env/browser.js
+++ b/tools/malwarejail/env/browser.js
@@ -266,17 +266,20 @@ Document = _proxy(function () {
         util_log(this._name + ".getElementsByClassName(" + n + ") ... " + ret.length + " found");
         return ret;
     };
-    this.getelementbyid = function (n) {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById
+        this.getelementbyid = function (n) {
         util_log(this._name + ".getElementById(" + n + ")");
         if (n === undefined) {
             return this._elements[0];
+        } else if (n.startsWith("#")) {
+            n = n.slice(1,);
         }
         // This list will contain elements that have interesting attributes
         elements_of_interest = [];
         for (i = 0; i < this._elements.length; i++) {
             let e = this._elements[i];
             // _nodename is a better representation of ID than _id
-            if (("" + e._nodename).toLowerCase() === n.toLowerCase()) {
+            if ("_nodename" in e && ("" + e._nodename).toLowerCase() === n.toLowerCase()) {
                 util_log(this._name + ".getElementById(" + n + ") => " + e._name);
                 return e;
             // If "id" is in attributes, we should try that
@@ -307,13 +310,19 @@ Document = _proxy(function () {
             return this.getElementById(n);
         }
     };
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement
     this.createelement = function (n) {
         util_log(this._name + ".createElement(" + n + ")");
         let e;
+        // If we need to create a custom element with certain attributes, add it's case here
         if (n.toLowerCase() === "iframe") {
             e = new HTMLIFrameElement();
         } else if (n.toLowerCase() === "style") {
             e = new Style();
+        } else if (n.toLowerCase() === "button") {
+            e = new Button(n);
+        } else if (n.toLowerCase() === "input") {
+            e = new Input(n);
         } else {
             e = new Element(n);
         }
@@ -461,11 +470,51 @@ $ = function (thing) {
     return document.getElementById(thing);
 };
 
-$.ajax = function (thing) {
-    util_log("$.ajax(" + JSON.stringify(thing) + ")");
-    ret = _proxy(new XMLHttpRequest(thing));
-    ret.open(thing.type, thing.url);
-}
+// https://api.jquery.com/Jquery.ajax/
+$.ajax = function (url, settings) {
+    util_log("$.ajax(" + JSON.stringify(url) + ")");
+    ret = _proxy(new XMLHttpRequest(url));
+    ret.open(url.type, url.url);
+};
+
+// https://api.jquery.com/jquery.getJSON/
+$.getJSON = function (url, data, success) {
+    util_log("$.getJSON(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",")) + ")")
+    if (data.constructor.name === "Function") {
+        var function_name = data.prototype.name;
+        if (function_name === undefined) {
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+            function_name = "anonymous";
+        }
+        util_log("Running function " + function_name + "()");
+        var ret = _proxy(new XMLHttpRequest());
+        ret.open("get", url);
+        ret.send();
+        if (url.includes("ip") || url.includes("geo")) {
+            var response = {
+                "ip": "127.0.0.1",
+                "continent_code": "NA",
+                "country": "Canada",
+                "country_code": "CA",
+                "region": "Ottawa",
+                "region_code": "OW",
+                "city": "Ottawa",
+            };
+            data(response);
+        } else {
+            data();
+        }
+    }
+};
+
+// https://api.jquery.com/jQuery.post/
+$.post = function (url, data, success, dataType) {
+    util_log("$.post(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",")) + ")")
+    var ret = _proxy(new XMLHttpRequest());
+    ret.open("post", url);
+    ret.onreadystatechange = success;
+    ret.send(data);
+};
 
 Object.defineProperty(document, "location", {
     get: function () {

--- a/tools/malwarejail/env/console.js
+++ b/tools/malwarejail/env/console.js
@@ -1,3 +1,4 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/console
 console = _proxy({
     _name: "console",
     time: function(a) {
@@ -56,6 +57,9 @@ console = _proxy({
     },
     warn: function(a) {
         util_log(this._name + ".warn(" + a + ")");
+    },
+    exception: function(a) {
+        util_log(this._name + ".exception(" + a + ")");
     }
 })
 console.toString = () => { return "console" }

--- a/tools/malwarejail/env/wscript.js
+++ b/tools/malwarejail/env/wscript.js
@@ -1643,6 +1643,7 @@ Msxml2_DOMDocument_6_0.toString = () => {
 }
 
 // Pretty much a copy of MSXML2_XMLHTTP
+// https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 XMLHttpRequest = function () {
     this.id = _object_id++;
     this._name = "XMLHttpRequest[" + this.id + "]";
@@ -1651,17 +1652,18 @@ XMLHttpRequest = function () {
     this.toString = this.tostring = () => {
         return this._name
     }
-    this.open = function (m, u, a) {
-        u = u.replace(/\r|\n/g, "");
-        util_log(this._name + _truncateOutput((".open(" + m + "," + u + "," + a + ")")));
-        match = u.match(appendChild_base64_regex);
+    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/open
+    this.open = function (method, url, async, user, password) {
+        url = url.replace(/\r|\n/g, "");
+        util_log(this._name + _truncateOutput((".open(" + method + "," + url + "," + async + ")")));
+        match = url.match(appendChild_base64_regex);
         if (match) {
             util_log("Base64 match, decoding...");
             _wscript_saved_files[this._name] = Buffer.from(match[1], 'base64');
         }
-        this.method = m;
-        this.url = u;
-        switch (("" + a).toLowerCase()) {
+        this.method = method;
+        this.url = url;
+        switch (("" + async).toLowerCase()) {
             case "false":
             case "no":
             case "0":
@@ -1675,10 +1677,15 @@ XMLHttpRequest = function () {
         }
         // TODO: exit if URL seen x times
         this._wscript_urls_index = _wscript_urls.length
-        _wscript_urls[this._wscript_urls_index] = { "url": u, "method": m };
+        _wscript_urls[this._wscript_urls_index] = { "url": url, "method": method };
     }
-    this.send = function (a) {
-        util_log(this._name + ".send(" + a + ")");
+    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send
+    this.send = function (body) {
+        if (body == undefined) {
+            util_log(this._name + ".send()");
+        } else {
+            util_log(this._name + ".send(" + JSON.stringify(body) + ")");
+        }
         if (_download === "Yes") {
             try {
                 var res = _sync_request(this.method, this.url, {
@@ -1705,9 +1712,12 @@ XMLHttpRequest = function () {
                 _wscript_urls[this._wscript_urls_index]["request_body"] = a;
                 _wscript_urls[this._wscript_urls_index]["statustext"] = this.statustext;
             }
+            // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readystatechange_event
             if (this.onreadystatechange) {
                 util_log(this._name + ".onreadystatechange()");
-                this.onreadystatechange();
+                // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
+                var e = new Event("DONE");
+                this.onreadystatechange(e);
             }
             return;
         } else if (_download === "No") {
@@ -1721,7 +1731,8 @@ XMLHttpRequest = function () {
             this.readystate = 4;
             if (this.onreadystatechange) {
                 util_log(this._name + " Calling onreadystatechange() with dummy data");
-                this.onreadystatechange();
+                var e = new Event("DONE");
+                this.onreadystatechange(e);
             }
         } else if (_download === "Return HTTP/404") {
             util_log(this._name + " Intentionally returning HTTP/404");
@@ -1729,8 +1740,9 @@ XMLHttpRequest = function () {
             this.status = 404;
             this.readystate = 4;
             if (this.onreadystatechange) {
-                util_log(this._name + " Calling onreadystatechange()");
-                this.onreadystatechange();
+                util_log(this._name + ".onreadystatechange()");
+                var e = new Event("DONE");
+                this.onreadystatechange(e);
             }
         } else if (_download === "Throw HTTP/404") {
             util_log(this._name + " Intentionally returning HTTP/404 & throwing exception");
@@ -1738,15 +1750,16 @@ XMLHttpRequest = function () {
             this.status = 404;
             this.readystate = 4;
             if (this.onreadystatechange) {
-                util_log(this._name + " Calling onreadystatechange()");
-                this.onreadystatechange();
+                util_log(this._name + ".onreadystatechange()");
+                var e = new Event("DONE");
+                this.onreadystatechange(e);
             }
             throw new Error("XMLHttpRequest.send intentionally throwing exception");
         } else {
             util_log(">>> FIXME: XMLHttpRequest.send _download '" + _download + "' not handled");
             throw new TypeError(">>> FIXME: XMLHttpRequest.send _download '" + _download + "' not handled");
         }
-        util_log(this._name + ".send(" + a + ") finished");
+        util_log(this._name + ".send(" + JSON.stringify(body) + ") finished");
     }
 }
 
@@ -1923,6 +1936,8 @@ Style = _proxy(function (css_text = "") {
             cssText: css_text
         }
     };
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/background-image
+    this.backgroundImage = null;
     this.toString = this.tostring = () => {
         return this._name;
     }
@@ -2087,7 +2102,6 @@ Element = _proxy(function (n) {
     _defineSingleProperty(this, "innertext", "_text");
     _defineSingleProperty(this, "outerhtml", "_outerHTML");
     _defineSingleProperty(this, "style", "_style");
-    _defineSingleProperty(this, "text", "_text");
     _defineSingleProperty(this, "id", "_id");
     _defineSingleProperty(this, "href", "_text");
     _defineSingleProperty(this, "dataset");
@@ -2123,6 +2137,26 @@ Element = _proxy(function (n) {
         else if (this.href)
             URL.revokeObjectURL(this.href);
     }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/append
+    this.append = function () {
+         for (param of arguments) {
+            this._children.push(param);
+            util_log(this._name + ".append(" + param + ")");
+        }
+    }
+    Object.defineProperty(this, "text", {
+        // I have no idea why text is a callable method... but hey it works!
+        get: function () {
+            util_log(this._name + ".text() => () => " + this._text);
+            return function() {
+                return this._text;
+            }
+        },
+        set: function (v) {
+            util_log(this._name + ".text = '" + v + "'");
+            this._text = v;
+        }
+    })
 });
 Element.prototype = Object.create(Node.prototype);
 Element.prototype.constructor = Element;
@@ -2157,6 +2191,54 @@ HTMLIFrameElement.prototype = Object.create(HTMLElement.prototype);
 HTMLIFrameElement.prototype.constructor = HTMLIFrameElement;
 HTMLIFrameElement.toString = HTMLIFrameElement.toJSON = () => {
     return "HTMLIFrameElement"
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
+Button = _proxy(function (n) {
+    Element.call(this, n);
+    this._id = _object_id++;
+    this._name = "Button[" + this._id + "]";
+    this.elementName = "button";
+    this._attributes = {};
+    util_log("new " + this._name + "()");
+    this.on = function(action, fn) {
+        if (fn.constructor.name === "Function") {
+            var function_name = fn.prototype.name;
+            if (function_name === undefined) {
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+                function_name = "anonymous";
+            }
+            util_log(this._name + "." + action + "(" + function_name + ")")
+            util_log("Running function " + function_name + "()");
+            fn();
+        }
+        else {
+            util_log("That's weird, a non-function was passed to button.on...")
+        }
+    }
+});
+Button.prototype = Object.create(Element.prototype);
+Button.prototype.constructor = Button;
+Button.toString = Button.toJSON = () => {
+    return "Button"
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input
+Input = _proxy(function (n) {
+    Element.call(this, n);
+    this._id = _object_id++;
+    this._name = "Input[" + this._id + "]";
+    this.elementName = "input";
+    this._attributes = {};
+    util_log("new " + this._name + "()");
+    this.val = function() {
+        return "JsJ@w$==C00l!";
+    }
+});
+Input.prototype = Object.create(Element.prototype);
+Input.prototype.constructor = Input;
+Input.toString = Input.toJSON = () => {
+    return "Input"
 }
 
 _WidgetManager = function () {

--- a/tools/malwarejail/jailme.js
+++ b/tools/malwarejail/jailme.js
@@ -435,21 +435,22 @@ var dump_sandbox = function () {
         return createHash('sha256').update(content).digest('hex')
     }
     s2.sha256 = sha256;
-    let c = `var _f = function(t) {
+    let c = `
+    var _f = function(t) {
         var out;
         out = JSON.stringify(JSON.decycle(sandbox), function(key, value) {
-                // convert functions to string
-                if (typeof value === 'function') {
-                    try {
-                        return value.toString();
-                    } catch (err) {
-                        util_log("Exception occured: " + typeof err + " ==> " + util_inspect(err));
-                        util_log("Object details: " + typeof value + " ==> " + util_inspect(value));
-                        return "!!! Exception occured !!!";
-                    }
+            // convert functions to string
+            if (typeof value === 'function') {
+                try {
+                    return value.toString();
+                } catch (err) {
+                    util_log("Exception occured: " + typeof err + " ==> " + util_inspect(err));
+                    util_log("Object details: " + typeof value + " ==> " + util_inspect(value));
+                    return "!!! Exception occured !!!";
                 }
-                    return value;
-                }, 4);
+            }
+            return value;
+        }, 4);
 
         writeFile(config.context_dump_after, out);
         util_log("The sandbox context has been  saved to: " + config.context_dump_after);
@@ -544,7 +545,7 @@ var dump_sandbox = function () {
             util_log("Saving: " + fname);
             writeFile(fname, out);
         }
-     }
+    }
 
     _f();
     `

--- a/tools/package.json
+++ b/tools/package.json
@@ -14,14 +14,14 @@
         "node": ">=6.0.0"
     },
     "dependencies": {
+        "@nodesecure/js-x-ray": "^5.1.0",
+        "box-js": "^1.9.15",
+        "deobfuscator": "^2.4.0",
         "entities": "^1.1.1",
         "iconv-lite": "^0.4.13",
         "log-timestamp": "0.3.0",
-        "sync-request": "^3.0.1",
-        "box-js": "^1.9.15",
-        "@nodesecure/js-x-ray": "^5.1.0",
         "minimist": "^1.2.0",
-        "deobfuscator": "^2.4.0"
+        "sync-request": "^3.0.1"
     },
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
Dependent on https://github.com/CybercentreCanada/assemblyline-v4-service/pull/486

The changes in the PR are due to the following reasons:
- `README.md`:
  - Adding an explanation for why there is an `al_config/system_safelist.yaml` file now
- `al_config/system_safelist.yaml`:
  - There are frequently domains and URIs used in JavaScript/HTML files that are benign, such as style sheets or external libraries. This file will attempt to keep track of them and prevent these domains / URIs from being flagged.
- `requirements.txt`:
  - We need the `PyYAML` library to import the safelist file
- `signatures/network.py`:
  - Tweaking the description of the `ajax_network_request` to indicate that it also uses jQuery
  - Adding a signature for any network request made using pure jQuery calls
- `tests/results/*/result.json`:
  - Due to the changes which will be described under the `jsjaws.py` section, the hashes of `temp_javascript.js` file will have changed, as well as the Element indices and types.
- `tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json`:
  - With the tweaks made to MalwareJail and JsJaws, we are able to detonate further into this sample, hence the additional marks raised for signatures.
- `tools/js-x-ray-run.js`:
  - We are passing divider string and using it to split the generated code from JsJaws and the actual script, so that JS-X-Ray only runs on the actual script. This is necessary for a lot of JS-X-Ray's detection.
- `tools/malwarejail/env/browser.js`:
  - Added more functions and capabilities to the `browser` module to facilitate additional environment variables and methods
  - Set up a default response if `$.getJSON` is called and the URL requested is for a Geo-IP service.
- `tools/malwarejail/env/console.js`:
  - Adding the `exception` function, even though it is deprecated, it is used by some samples.
- `tools/malwarejail/env/wscript.js`:
  - Replaced generic shorthand variables in certain methods with the actual variable names as per MDN documentation
  - Passing an event to the `onreadystatechange` method, since that is what it is expecting.
  - Added more functions and capabilities to the `wscript` module to facilitate additional environment variables and methods
  - The `text` getter is still confusing to me. There is no documentation on it that I can find, and no browser supports its use, but for some reason some samples use it in this way...
  - If a Button is created with a function to occur on click, run that function
  - If an Input is created and the `val()` method is called, return a fake password
- `tools/malwarejail/jailme.js`:
  - Pretty-print the context method
- `tools/package.json`:
  - Reorder the dependencies
- `jsjaws.py`:
  - One major update taking place in this file:
    - We are no longer using a regular expression to hunt the plaintext JavaScript for where an element is requested via "getElementById" and then programatically created those elements with JsJaws, since in more sophisticated samples this code is obfuscated. So we are now creating *most* elements in the HTML programatically with JsJaws and adding a divider to identify where this code ends and the actual code begins.
    - This divider is key to JS-X-Ray's detection, mentioned above.
    - We also can use this divider to insert code above it, as seen in `insert_content()`.