### PR TITLE
Many changes that stemmed from cryptojs obfuscation capabilities

### DIFF
--- a/al_config/system_safelist.yaml
+++ b/al_config/system_safelist.yaml
@@ -10,6 +10,8 @@ regex:
   - www\.w3\.org$
   # Bootstrap
   - getbootstrap\.com$
+  # Microsoft Auth
+  - aadcdn\.msftauth\.net$
   network.dynamic.uri:
   # GoogleAPIs
   - https?://.*\.googleapis\.com(?:$|/.*)
@@ -21,3 +23,5 @@ regex:
   - https?://www\.w3\.org(?:$|/.*)
   # Bootstrap
   - https?://getbootstrap\.com(?:$|/.*)
+  # Microsoft Auth
+  - https?://aadcdn\.msftauth\.net(?:$|/.*)

--- a/jsjaws.py
+++ b/jsjaws.py
@@ -112,8 +112,6 @@ class JsJaws(ServiceBase):
         self.extracted_wscript_path: Optional[str] = None
         self.malware_jail_output: Optional[str] = None
         self.malware_jail_output_path: Optional[str] = None
-        self.extracted_doc_writes: Optional[str] = None
-        self.extracted_doc_writes_path: Optional[str] = None
         self.boxjs_output_dir: Optional[str] = None
         self.boxjs_iocs: Optional[str] = None
         self.boxjs_resources: Optional[str] = None
@@ -126,6 +124,7 @@ class JsJaws(ServiceBase):
         self.stdout_limit: Optional[int] = None
         self.identify = forge.get_identify(use_cache=environ.get("PRIVILEGED", "false").lower() == "true")
         self.safelist: Dict[str, Dict[str, List[str]]] = {}
+        self.doc_write_hashes: Optional[Set[str]] = None
         self.log.debug("JsJaws service initialized")
 
     def start(self) -> None:
@@ -146,28 +145,11 @@ class JsJaws(ServiceBase):
         self.log.debug("JsJaws service ended")
 
     def execute(self, request: ServiceRequest) -> None:
-        request.result = Result()
-        self.artifact_list = []
+        # Reset per sample
+        self.doc_write_hashes = set()
+
         file_path = request.file_path
-
-        with open(file_path, "rb") as fh:
-            file_content = fh.read()
-
-        css_path = None
-        if request.file_type in ["code/html", "code/hta"]:
-            file_path, file_content, css_path = self.extract_using_soup(request, file_content)
-        elif request.file_type == "image/svg":
-            file_path, file_content, _ = self.extract_using_soup(request, file_content)
-
-        if file_path is None:
-            return
-
-        # If the file starts or ends with null bytes, let's strip them out
-        if file_content.startswith(b"\x00") or file_content.endswith(b"\x00"):
-            with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as f:
-                file_content = file_content[:].strip(b"\x00")
-                f.write(file_content)
-                file_path = f.name
+        file_content = request.file_contents
 
         # This is a VBScript method of setting an environment variable:
         #
@@ -214,8 +196,6 @@ class JsJaws(ServiceBase):
         self.extracted_wscript_path = path.join(self.malware_jail_payload_extraction_dir, self.extracted_wscript)
         self.malware_jail_output = "output.txt"
         self.malware_jail_output_path = path.join(self.working_directory, self.malware_jail_output)
-        self.extracted_doc_writes = "document_writes.html"
-        self.extracted_doc_writes_path = path.join(self.malware_jail_payload_extraction_dir, self.extracted_doc_writes)
         self.boxjs_output_dir = path.join(self.working_directory, f"{request.sha256}.results")
         self.boxjs_urls_json_path = path.join(self.boxjs_output_dir, "urls.json")
         self.boxjs_iocs = path.join(self.boxjs_output_dir, "IOC.json")
@@ -233,6 +213,42 @@ class JsJaws(ServiceBase):
 
         if not path.exists(self.malware_jail_sandbox_env_dir):
             mkdir(self.malware_jail_sandbox_env_dir)
+
+        self.run_the_gauntlet(request, file_path, file_content)
+
+    def run_the_gauntlet(self, request, file_path, file_content, subsequent_run: bool = False) -> None:
+        """
+        Welcome to the gauntlet. This is the method that you call when you want a file to run through all of the JsJaws tools and signatures. Ideally you should only call this when you are running an "improved" or "superset" version of the initial sample, since it will overwrite all result sections and artifacts from previous gauntlet runs.
+        :param request: The ServiceRequest object
+        :param file_path: The path of the file to use as we traverse this iteration of the gauntlet
+        :param file_content: The content of the file to use as we traverse this iteration of the gauntlet
+        :param subsequent_run: A flag indicating if this is not the initial gauntlet run
+        :return: None
+        """
+        # Reset per gauntlet run
+        self.artifact_list = []
+        request.result = Result()
+        if not subsequent_run:
+            file_type = request.file_type
+        else:
+            file_type_details = self.identify.fileinfo(file_path)
+            file_type = file_type_details["type"]
+
+        css_path = None
+        if file_type in ["code/html", "code/hta"]:
+            file_path, file_content, css_path = self.extract_using_soup(request, file_content)
+        elif file_type == "image/svg":
+            file_path, file_content, _ = self.extract_using_soup(request, file_content)
+
+        if file_path is None:
+            return
+
+        # If the file starts or ends with null bytes, let's strip them out
+        if file_content.startswith(b"\x00") or file_content.endswith(b"\x00"):
+            with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as f:
+                file_content = file_content[:].strip(b"\x00")
+                f.write(file_content)
+                file_path = f.name
 
         # Grabbing service level configuration variables and submission variables
         download_payload = request.get_param("download_payload")
@@ -358,7 +374,9 @@ class JsJaws(ServiceBase):
         tool_threads: List[Thread] = []
         responses: Dict[str, List[str]] = {}
         if not static_analysis_only:
-            tool_threads.append(Thread(target=self._run_tool, args=("Box.js", boxjs_args, responses), daemon=True))
+            if not subsequent_run:
+                # Box.js cannot handle being run more than once on a sample. Oh well!
+                tool_threads.append(Thread(target=self._run_tool, args=("Box.js", boxjs_args, responses), daemon=True))
             tool_threads.append(Thread(target=self._run_tool, args=("MalwareJail", malware_jail_args, responses), daemon=True))
         tool_threads.append(Thread(target=self._run_tool, args=("JS-X-Ray", jsxray_args, responses), daemon=True))
 
@@ -384,6 +402,8 @@ class JsJaws(ServiceBase):
 
         for thr in tool_threads:
             thr.join(timeout=tool_timeout)
+            if thr.is_alive():
+                self.log.debug("A tool did not finish. Look at previous logs...")
 
         boxjs_output: List[str] = []
         if path.exists(self.boxjs_analysis_log):
@@ -422,9 +442,8 @@ class JsJaws(ServiceBase):
         self._run_signatures(total_output, request.result, display_iocs)
 
         self._extract_boxjs_iocs(request.result)
-        self._extract_malware_jail_iocs(malware_jail_output, request)
+        self._extract_malware_jail_iocs(malware_jail_output[: self.stdout_limit], request)
         self._extract_wscript(total_output, request.result)
-        self._extract_doc_writes(malware_jail_output, request)
         self._extract_payloads(request.sha256, request.deep_scan)
         self._extract_urls(request.result)
         try:
@@ -445,6 +464,9 @@ class JsJaws(ServiceBase):
         _ = responses.get("Synchrony")
 
         self._extract_synchrony(request.result)
+
+        # This has to be the second last thing that we do, since it will run on a "superset" of the initial file...
+        self._extract_doc_writes(malware_jail_output[: self.stdout_limit], request)
 
         # Adding sandbox artifacts using the OntologyResults helper class
         _ = OntologyResults.handle_artifacts(self.artifact_list, request)
@@ -509,8 +531,14 @@ class JsJaws(ServiceBase):
 
         if aggregated_js_script:
             aggregated_js_script.close()
+            artifact = {
+                "name": "temp_javascript.js",
+                "path": aggregated_js_script.name,
+                "description": "Extracted JavaScript",
+                "to_be_extracted": False,
+            }
             self.log.debug("Adding extracted JavaScript: temp_javascript.js")
-            request.add_supplementary(aggregated_js_script.name, "temp_javascript.js", "Extracted JavaScript")
+            self.artifact_list.append(artifact)
             js_script_name = aggregated_js_script.name
 
         if js_content != b"":
@@ -539,8 +567,14 @@ class JsJaws(ServiceBase):
                 with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as t:
                     t.write(embedded_file_content)
                     embed_path = t.name
+                artifact = {
+                    "name": get_sha256_for_file(embed_path),
+                    "path": embed_path,
+                    "description": "Base64-decoded Embed Tag Source",
+                    "to_be_extracted": True,
+                }
                 self.log.debug(f"Extracting decoded embed tag source {embed_path}")
-                request.add_extracted(embed_path, get_sha256_for_file(embed_path), "Base64-decoded Embed Tag Source")
+                self.artifact_list.append(artifact)
 
                 # We also want to aggregate Javscript scripts, but prior to the DIVIDING_COMMENT break, if it exists
                 file_info = self.identify.ident(embedded_file_content, len(embedded_file_content), embed_path)
@@ -591,7 +625,8 @@ class JsJaws(ServiceBase):
 
             # If the element does not have an ID, mock one
             element_id = element.attrs.get("id", f"element{idx}")
-            random_element_varname = f"{element_id.lower()}_jsjaws"
+            # JavaScript variables cannot have hyphens in their names
+            random_element_varname = f"{element_id.lower().replace('-', '_')}_jsjaws"
             # We cannot trust the text value of these elements, since it contains all nested items within it...
             if element.name in ["div", "p", "svg"]:
                 # If the element contains a script child, and the element's string is the same as the script child's, set value to None
@@ -616,6 +651,12 @@ class JsJaws(ServiceBase):
                 create_element_script += f"{random_element_varname}.innertext = \"{element_value}\";\n"
             for attr_id, attr_val in element.attrs.items():
                 if attr_id != "id":
+                    # Escape double quotes since we are wrapping the value in double quotes
+                    if '"' in attr_val:
+                        attr_val = attr_val.replace('"', '\\"')
+                    # JavaScript does not like when there are newlines when setting attributes
+                    if isinstance(attr_val, str) and "\n" in attr_val:
+                        attr_val = attr_val.replace("\n", "")
                     create_element_script += f"{random_element_varname}.setAttribute(\"{attr_id}\", \"{attr_val}\");\n"
 
             if insert_above_divider:
@@ -623,7 +664,7 @@ class JsJaws(ServiceBase):
             else:
                 js_content, aggregated_js_script = self.append_content(create_element_script, js_content, aggregated_js_script)
 
-        if not insert_above_divider:
+        if js_content and not insert_above_divider:
             # Add a break that is obvious for JS-X-Ray to differentiate
             js_content, aggregated_js_script = self.append_content(DIVIDING_COMMENT, js_content, aggregated_js_script)
 
@@ -706,8 +747,14 @@ class JsJaws(ServiceBase):
             aggregated_css_script.close()
 
             if style_json:
+                artifact = {
+                    "name": "temp_css.css",
+                    "path": aggregated_css_script.name,
+                    "description": "Extracted CSS",
+                    "to_be_extracted": False,
+                }
                 self.log.debug("Adding extracted CSS: temp_css.css")
-                request.add_supplementary(aggregated_css_script.name, "temp_css.css", "Extracted CSS")
+                self.artifact_list.append(artifact)
                 css_script_name = aggregated_css_script.name
 
                 # Look for suspicious CSS usage
@@ -729,7 +776,14 @@ class JsJaws(ServiceBase):
                                         with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False, mode="wb") as t:
                                             t.write(item["url"])
                                             url_path = t.name
-                                        request.add_extracted(url_path, get_sha256_for_file(url_path), "URL value from CSS")
+                                        artifact = {
+                                            "name": get_sha256_for_file(url_path),
+                                            "path": url_path,
+                                            "description": "URL value from CSS",
+                                            "to_be_extracted": True,
+                                        }
+                                        self.log.debug(f"Extracting URL value from CSS: {url_path}")
+                                        self.artifact_list.append(artifact)
                                         heur = Heuristic(7)
                                         _ = ResultTextSection(heur.name, heuristic=heur, parent=request.result, body=heur.description)
             else:
@@ -844,7 +898,6 @@ class JsJaws(ServiceBase):
             if extracted in [
                 self.malware_jail_urls_json_path,
                 self.extracted_wscript_path,
-                self.extracted_doc_writes_path,
                 self.boxjs_iocs,
                 self.boxjs_resources,
                 self.boxjs_snippets,
@@ -908,20 +961,30 @@ class JsJaws(ServiceBase):
         :return: None
         """
         doc_write = False
-        content_to_write = []
+        content_to_write_list = []
         for line in self._parse_malwarejail_output(output):
             if doc_write:
                 written_content = line.split("] => '", 1)[1].strip()[:-1]
-                content_to_write.append(written_content)
+                content_to_write_list.append(written_content)
                 doc_write = False
             if all(item in line.split("] ", 1)[1][:40] for item in ["document", "write(content)"]):
                 doc_write = True
 
-        with open(self.extracted_doc_writes_path, "w") as f:
-            f.write("\n".join(content_to_write))
+        if not content_to_write_list:
+            return
+
+        content_to_write = "\n".join(content_to_write_list).encode()
+        doc_write_hash = sha256(content_to_write).hexdigest()
+
+        if doc_write_hash in self.doc_write_hashes:
+            # To avoid recursive gauntlet runs, perform this check
+            self.log.debug("No new content written to the DOM...")
+            return
+
+        self.doc_write_hashes.add(doc_write_hash)
 
         visible_text: Set[str] = set()
-        for line in content_to_write:
+        for line in content_to_write_list:
             visible_text.update(self._extract_visible_text_using_soup(line))
         if any(any(WORD in line.lower() for WORD in PASSWORD_WORDS) for line in visible_text):
             new_passwords = set()
@@ -941,16 +1004,17 @@ class JsJaws(ServiceBase):
                     new_passwords.update(set(request.temp_submission_data["passwords"]))
                 request.temp_submission_data["passwords"] = sorted(list(new_passwords))
 
-        if path.getsize(self.extracted_doc_writes_path) > 0:
-            self.artifact_list.append(
-                {
-                    "name": self.extracted_doc_writes,
-                    "path": self.extracted_doc_writes_path,
-                    "description": "DOM Writes",
-                    "to_be_extracted": True,
-                }
-            )
-            self.log.debug(f"Adding extracted file: {self.extracted_doc_writes}")
+        # The entire point of writing elements into the document is to manipulate the DOM. If certain elements contain script elements that depend on previously declared variables, then we should build an HTML file will all content possible and send that through the gauntlet again.
+
+        total_dom_contents = request.file_contents
+        total_dom_contents += b"\n"
+        total_dom_contents += content_to_write
+        with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False) as out:
+            out.write(total_dom_contents)
+            total_dom_path = out.name
+
+        self.log.debug("There were elements written to the DOM. Time to run the gauntlet again!")
+        self.run_the_gauntlet(request, total_dom_path, total_dom_contents, subsequent_run=True)
 
     def _extract_urls(self, result: Result) -> None:
         """
@@ -1077,7 +1141,7 @@ class JsJaws(ServiceBase):
         self.log.debug(f"Running {len(sigs)} signatures...")
         start_time = time()
         for sig in sigs:
-            thr = Thread(target=self._process_signature, args=(sig, output, signatures_that_hit))
+            thr = Thread(target=self._process_signature, args=(sig, output, signatures_that_hit), daemon=True)
             sig_threads.append(thr)
             thr.start()
 
@@ -1381,9 +1445,14 @@ class JsJaws(ServiceBase):
 
                         with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False) as out:
                             out.write(encoded_content)
-                    request.add_extracted(
-                        out.name, sha256(encoded_content).hexdigest(), "Redirection location"
-                    )
+                    artifact = {
+                        "name": sha256(encoded_content).hexdigest(),
+                        "path": out.name,
+                        "description": "Redirection location",
+                        "to_be_extracted": True,
+                    }
+                    self.log.debug(f"Redirection location: {out.name}")
+                    self.artifact_list.append(artifact)
                 else:
                     heur = Heuristic(6)
                     res = ResultTextSection(heur.name, heuristic=heur, parent=request.result)
@@ -1409,6 +1478,9 @@ class JsJaws(ServiceBase):
             with Popen(args=args, stdout=PIPE, bufsize=1, universal_newlines=True) as p:
                 for line in p.stdout:
                     resp[tool_name].append(line)
+                    if len(resp[tool_name]) > self.stdout_limit:
+                        self.log.warning(f"{tool_name} generated more than {self.stdout_limit} lines of output. Time elapsed: {round(time() - start_time)}s")
+                        return
         except TimeoutExpired:
             pass
         except Exception as e:

--- a/signatures/decode.py
+++ b/signatures/decode.py
@@ -58,3 +58,17 @@ class Obfuscation(Signature):
 
     def process_output(self, output):
         self.check_indicators_in_list(output)
+
+
+class CryptoJSObfuscation(Signature):
+    def __init__(self):
+        super().__init__(
+            heuristic_id=3,
+            name="crypto_js_obfuscation",
+            description="JavaScript uses CryptoJS for obfuscating/de-obfuscating a string",
+            indicators=["CryptoJS"],
+            severity=0
+        )
+
+    def process_output(self, output):
+        self.check_indicators_in_list(output)

--- a/tests/results/21c885488414b47452c4b5c93acc96b73122c99739e79c8854fe880f41fe40f1/result.json
+++ b/tests/results/21c885488414b47452c4b5c93acc96b73122c99739e79c8854fe880f41fe40f1/result.json
@@ -126,7 +126,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tActiveXObject(System.Security.Cryptography.FromBase64Transform)\n\n\t\tnew System.Security.Cryptography.FromBase64Transform[22]\n\n\t\tSystem.Security.Cryptography.FromBase64Transform[22].TransformFinalBlock(65,65,69,65,65,65,68,47,47,...\n\t\tSaving: /tmp/working_directory/tmp0l6c28ss/payload/System.Security.Cryptography.FromBase64Transform[...",
+        "body": "JavaScript uses a common base64 method for decoding characters\n\t\tActiveXObject(System.Security.Cryptography.FromBase64Transform)\n\n\t\tnew System.Security.Cryptography.FromBase64Transform[22]\n\n\t\tSystem.Security.Cryptography.FromBase64Transform[22].TransformFinalBlock(65,65,69,65,65,65,68,47,47,...\n\t\tSaving: /tmp/working_directory/tmp57203cdg/payload/System.Security.Cryptography.FromBase64Transform[...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -412,7 +412,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"paknavy-gov-pk.downld.net\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/\"}]",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"paknavy-gov-pk.downld.net\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -431,11 +431,9 @@
                 "paknavy-gov-pk.downld.net"
               ],
               "uri": [
-                "https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)",
                 "https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/"
               ],
               "uri_path": [
-                "/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)",
                 "/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/"
               ]
             }
@@ -676,11 +674,6 @@
           "heur_id": 2,
           "signatures": [],
           "value": "https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "https://paknavy-gov-pk.downld.net/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)"
         }
       ],
       "network.dynamic.uri_path": [
@@ -693,11 +686,6 @@
           "heur_id": 2,
           "signatures": [],
           "value": "/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "/14578/1/6277/3/1/1/1856303893/fra9ancdjiaq12rcbuahxveak5kmltaitupzdqrd/files-1f77d26e/1/)"
         }
       ]
     },

--- a/tests/results/55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09/result.json
+++ b/tests/results/55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1042,
+    "score": 1052,
     "sections": [
       {
         "auto_collapse": false,
@@ -12,6 +12,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "A domain associated with GeoIP services was observed\n\t\tDomain 'ip.seeip.org' is for a GeoIP service.\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "geoip_service_request": 10
+          },
+          "signatures": {
+            "geoip_service_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: GeoIPServiceRequest",
         "zeroize_on_tag_safe": false
       },
       {
@@ -108,7 +130,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"getbootstrap.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/docs/5.2/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/docs/5.2/examples/sign-in/signin.css\"}, {\"ioc_type\": \"domain\", \"ioc\": \"liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"logo.clearbit.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://logo.clearbit.com/liftca.org\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ip.seeip.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ip.seeip.org/geoip\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/geoip\"}, {\"ioc_type\": \"domain\", \"ioc\": \"api.telegram.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ia801500.us.archive.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}]",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"logo.clearbit.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://logo.clearbit.com/liftca.org\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ip.seeip.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ip.seeip.org/geoip\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/geoip\"}, {\"ioc_type\": \"domain\", \"ioc\": \"api.telegram.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ia801500.us.archive.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -124,7 +146,6 @@
           "network": {
             "dynamic": {
               "domain": [
-                "getbootstrap.com",
                 "liftca.org",
                 "logo.clearbit.com",
                 "ip.seeip.org",
@@ -135,16 +156,12 @@
                 "127.0.0.1"
               ],
               "uri": [
-                "https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css",
-                "https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css",
                 "https://logo.clearbit.com/liftca.org",
                 "https://ip.seeip.org/geoip",
                 "https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage",
                 "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
               ],
               "uri_path": [
-                "/docs/5.2/dist/css/bootstrap.min.css",
-                "/docs/5.2/examples/sign-in/signin.css",
                 "/liftca.org",
                 "/geoip",
                 "/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage",
@@ -208,7 +225,7 @@
       },
       {
         "name": "temp_javascript.js",
-        "sha256": "e8e868eddaff3927b4afc896180eb438d4e19b1a08899e273de43f61bdaf2d35"
+        "sha256": "59b5e4bfe50549ad42708edddcdfd90c9d247186d3d8ee44137cdb60687106af"
       }
     ]
   },
@@ -223,6 +240,13 @@
         "attack_ids": [],
         "heur_id": 2,
         "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "geoip_service_request"
+        ]
       },
       {
         "attack_ids": [],
@@ -266,11 +290,6 @@
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "getbootstrap.com"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
           "value": "ia801500.us.archive.org"
         },
         {
@@ -305,16 +324,6 @@
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
           "value": "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
         },
         {
@@ -338,16 +347,6 @@
           "heur_id": 2,
           "signatures": [],
           "value": "/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "/docs/5.2/dist/css/bootstrap.min.css"
-        },
-        {
-          "heur_id": 2,
-          "signatures": [],
-          "value": "/docs/5.2/examples/sign-in/signin.css"
         },
         {
           "heur_id": 2,

--- a/tests/results/55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09/result.json
+++ b/tests/results/55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09/result.json
@@ -1,0 +1,373 @@
+{
+  "extra": {
+    "drop_file": false,
+    "score": 1042,
+    "sections": [
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": null,
+        "tags": {},
+        "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript sends a network request via jQuery\n\t\t$.getJSON(https://ip.seeip.org/geoip,function(_0x5ce0c5){function _0x7f297f(_0x19b56f,_0x52f5d0,_0x5...\n\t\t$.post(https://api.telegram.org/bot1843792137:AAEK1uKnboDz64W-OXeP8M3behanH1pvFhw/sendMessage,[objec...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "jquery_network_request": 10
+          },
+          "signatures": {
+            "jquery_network_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: JQueryNetworkRequest",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript sends a network request\n\t\tXMLHttpRequest[47].send()\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "network_request": 10
+          },
+          "signatures": {
+            "network_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: NetworkRequest",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript appends a child object to the document and clicks it\n\t\tButton[37].click(anonymous)\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "append_and_click": 10
+          },
+          "signatures": {
+            "append_and_click": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: AppendAndClick",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Redirection to:\nhttps://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3'",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 6,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {
+          "network": {
+            "static": {
+              "uri": [
+                "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3'"
+              ]
+            }
+          }
+        },
+        "title_text": "Automatic location redirection",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"getbootstrap.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/docs/5.2/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/docs/5.2/examples/sign-in/signin.css\"}, {\"ioc_type\": \"domain\", \"ioc\": \"liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"logo.clearbit.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://logo.clearbit.com/liftca.org\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/liftca.org\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ip.seeip.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ip.seeip.org/geoip\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/geoip\"}, {\"ioc_type\": \"domain\", \"ioc\": \"api.telegram.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"domain\", \"ioc\": \"ia801500.us.archive.org\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3\"}]",
+        "body_format": "TABLE",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 2,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {
+          "network": {
+            "dynamic": {
+              "domain": [
+                "getbootstrap.com",
+                "liftca.org",
+                "logo.clearbit.com",
+                "ip.seeip.org",
+                "api.telegram.org",
+                "ia801500.us.archive.org"
+              ],
+              "ip": [
+                "127.0.0.1"
+              ],
+              "uri": [
+                "https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css",
+                "https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css",
+                "https://logo.clearbit.com/liftca.org",
+                "https://ip.seeip.org/geoip",
+                "https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage",
+                "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
+              ],
+              "uri_path": [
+                "/docs/5.2/dist/css/bootstrap.min.css",
+                "/docs/5.2/examples/sign-in/signin.css",
+                "/liftca.org",
+                "/geoip",
+                "/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage",
+                "/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
+              ]
+            }
+          }
+        },
+        "title_text": "MalwareJail extracted the following IOCs",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "\t\tObfuscated code was found that was obfuscated by: obfuscator.io",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 2,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "JS-X-Ray IOCs Detected",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "View extracted file 55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09.cleaned for details.",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 8,
+          "score": 1000,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "The file was deobfuscated/cleaned by Synchrony",
+        "zeroize_on_tag_safe": false
+      }
+    ]
+  },
+  "files": {
+    "extracted": [
+      {
+        "name": "55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09.cleaned",
+        "sha256": "a16e0519cb18e366e58cf2954d6503abd76bf01148c85ef1adb3a0eac5da627a"
+      }
+    ],
+    "supplementary": [
+      {
+        "name": "temp_css.css",
+        "sha256": "022ecf84054da1a43e75a877804bf4c7205d212faf1279d11b2c986fb058f5d4"
+      },
+      {
+        "name": "temp_javascript.js",
+        "sha256": "e8e868eddaff3927b4afc896180eb438d4e19b1a08899e273de43f61bdaf2d35"
+      }
+    ]
+  },
+  "results": {
+    "heuristics": [
+      {
+        "attack_ids": [],
+        "heur_id": 2,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 2,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "jquery_network_request"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "network_request"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "append_and_click"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 6,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 8,
+        "signatures": []
+      }
+    ],
+    "tags": {
+      "network.dynamic.domain": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "api.telegram.org"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "getbootstrap.com"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "ia801500.us.archive.org"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "ip.seeip.org"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "liftca.org"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "logo.clearbit.com"
+        }
+      ],
+      "network.dynamic.ip": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "127.0.0.1"
+        }
+      ],
+      "network.dynamic.uri": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://api.telegram.org/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://getbootstrap.com/docs/5.2/dist/css/bootstrap.min.css"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://getbootstrap.com/docs/5.2/examples/sign-in/signin.css"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://ip.seeip.org/geoip"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://logo.clearbit.com/liftca.org"
+        }
+      ],
+      "network.dynamic.uri_path": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/bot1843792137:aaek1uknbodz64w-oxep8m3behanh1pvfhw/sendmessage"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/docs/5.2/dist/css/bootstrap.min.css"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/docs/5.2/examples/sign-in/signin.css"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/geoip"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/liftca.org"
+        }
+      ],
+      "network.static.uri": [
+        {
+          "heur_id": 6,
+          "signatures": [],
+          "value": "https://ia801500.us.archive.org/34/items/7164025490-20221107-091147/7164025490_20221107_091147.mp3'"
+        }
+      ]
+    },
+    "temp_submission_data": {}
+  }
+}

--- a/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
+++ b/tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json
@@ -101,7 +101,7 @@
     "supplementary": [
       {
         "name": "temp_javascript.js",
-        "sha256": "d3165153bac461f0779452777fc69f2b4e5de614a8c828805df6e571efb5f030"
+        "sha256": "fd2f5346f0d894a5490a5880c1769c8d0e566cfa3a6f8305c6a3dd5fde29ef9a"
       }
     ]
   },

--- a/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
+++ b/tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json
@@ -197,10 +197,6 @@
       {
         "name": "attachment.zip",
         "sha256": "568f1ebd9c616164eaaec8ad7807f0fc600a5101ea99b441f91d559e3b419afc"
-      },
-      {
-        "name": "document_writes.html",
-        "sha256": "640ac074bec0e6ad82b795b6082fd0ae95c0a8976d70bb239fc41b9dcbd4f8d9"
       }
     ],
     "supplementary": [

--- a/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
+++ b/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
@@ -126,7 +126,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"onlinebanking.mtb.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://onlinebanking.mtb.com/login/mtbsignon\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/login/mtbsignon\"}, {\"ioc_type\": \"domain\", \"ioc\": \"usps.com\"}, {\"ioc_type\": \"domain\", \"ioc\": \"i.ibb.co\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://i.ibb.co/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/d1.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/d1.php\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/ads.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/ads.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"?load=1&session='+window['ip']\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/adminpanel/returnjson.php?session=127.0.0.1\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/adminpanel/returnjson.php?session=127.0.0.1\"}]",
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"onlinebanking.mtb.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://onlinebanking.mtb.com/login/mtbsignon\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/login/mtbsignon\"}, {\"ioc_type\": \"domain\", \"ioc\": \"usps.com\"}, {\"ioc_type\": \"domain\", \"ioc\": \"i.ibb.co\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://i.ibb.co/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/d1.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/d1.php\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/ads.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/ads.php\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/adminpanel/returnjson.php?session=127.0.0.1\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/adminpanel/returnjson.php?session=127.0.0.1\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"?load=1&session='+window['ip']\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -162,8 +162,8 @@
                 "/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif",
                 "/d1.php",
                 "/ads.php",
-                "?load=1&session='+window['ip']",
-                "/adminpanel/returnjson.php?session=127.0.0.1"
+                "/adminpanel/returnjson.php?session=127.0.0.1",
+                "?load=1&session='+window['ip']"
               ]
             }
           }

--- a/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
+++ b/tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1022,
+    "score": 1051,
     "sections": [
       {
         "auto_collapse": false,
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses unescape() to decode an encoded string\n\t\tCalling unescape() no.: 1\n\n\t\t}}}(_0x36ce,0xe3320),document['write'](unescape(_0x5ab5f6(0x1c5))))",
+        "body": "JavaScript sends a network request via jQuery\n\t\t$.getJSON(https://folderdata021755.tk/ads.php,function(_0x244311){var _0x4771b7=_0x1a3571,_0x5d510e=...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -26,14 +26,58 @@
           "heur_id": 3,
           "score": 10,
           "score_map": {
-            "unescape": 10
+            "jquery_network_request": 10
           },
           "signatures": {
-            "unescape": 1
+            "jquery_network_request": 1
           }
         },
         "tags": {},
-        "title_text": "Signature: Unescape",
+        "title_text": "Signature: JQueryNetworkRequest",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript sends a network request via AJAX and jQuery\n\t\t$.ajax({\"dataType\":\"JSON\",\"url\":\"https://folderdata021755.tk/d1.php\",\"type\":\"POST\",\"data\":{\"fn\":\"cli...\n\t\t$.ajax({\"url\":\"https://folderdata021755.tk/adminPanel/returnJson.php?session=127.0.0.1\",\"method\":\"GE...\n\t\t$.ajax({\"url\":\"https://folderdata021755.tk/adminPanel/returnJson.php?session=127.0.0.1\",\"method\":\"GE...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "ajax_network_request": 10
+          },
+          "signatures": {
+            "ajax_network_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: AJAXNetworkRequest",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript sends a network request\n\t\tXMLHttpRequest[278].send()\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "network_request": 10
+          },
+          "signatures": {
+            "network_request": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: NetworkRequest",
         "zeroize_on_tag_safe": false
       },
       {
@@ -60,7 +104,29 @@
       },
       {
         "auto_collapse": false,
-        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"domain\", \"ioc\": \"cdn.jsdelivr.net\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css\"}]",
+        "body": "JavaScript attempts to sleep\n\t\twindow[5].setTimeout(function(){var _0x4d6bb9=_0x4ac814;$(_0x4d6bb9(0x14c))['hide'](),$(_0x4d6bb9(0x...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "sleep": 10
+          },
+          "signatures": {
+            "sleep": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Sleep",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "[{\"ioc_type\": \"domain\", \"ioc\": \"onlinebanking.mtb.com\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://onlinebanking.mtb.com/login/mtbsignon\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/login/mtbsignon\"}, {\"ioc_type\": \"domain\", \"ioc\": \"usps.com\"}, {\"ioc_type\": \"domain\", \"ioc\": \"i.ibb.co\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://i.ibb.co/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif\"}, {\"ioc_type\": \"domain\", \"ioc\": \"folderdata021755.tk\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/d1.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/d1.php\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/ads.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/ads.php\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"?load=1&session='+window['ip']\"}, {\"ioc_type\": \"ip\", \"ioc\": \"127.0.0.1\"}, {\"ioc_type\": \"uri\", \"ioc\": \"https://folderdata021755.tk/adminpanel/returnjson.php?session=127.0.0.1\"}, {\"ioc_type\": \"uri_path\", \"ioc\": \"/adminpanel/returnjson.php?session=127.0.0.1\"}]",
         "body_format": "TABLE",
         "classification": "TLP:W",
         "depth": 0,
@@ -76,38 +142,33 @@
           "network": {
             "dynamic": {
               "domain": [
-                "folderdata021755.tk",
-                "cdn.jsdelivr.net"
+                "onlinebanking.mtb.com",
+                "usps.com",
+                "i.ibb.co",
+                "folderdata021755.tk"
+              ],
+              "ip": [
+                "127.0.0.1"
               ],
               "uri": [
-                "https://folderdata021755.tk",
-                "https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"
+                "https://onlinebanking.mtb.com/login/mtbsignon",
+                "https://i.ibb.co/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif",
+                "https://folderdata021755.tk/d1.php",
+                "https://folderdata021755.tk/ads.php",
+                "https://folderdata021755.tk/adminpanel/returnjson.php?session=127.0.0.1"
               ],
               "uri_path": [
-                "/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"
+                "/login/mtbsignon",
+                "/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif",
+                "/d1.php",
+                "/ads.php",
+                "?load=1&session='+window['ip']",
+                "/adminpanel/returnjson.php?session=127.0.0.1"
               ]
             }
           }
         },
         "title_text": "MalwareJail extracted the following IOCs",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "\t\tObfuscated code was found that was obfuscated by: obfuscator.io",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 2,
-          "score": 1,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "JS-X-Ray IOCs Detected",
         "zeroize_on_tag_safe": false
       },
       {
@@ -133,15 +194,16 @@
   "files": {
     "extracted": [
       {
-        "name": "document_writes.html",
-        "sha256": "d8dc6cdfb6f7adfbd25f4d191ccc3025961fc1ae93893113c58288877a23eae1"
-      },
-      {
         "name": "c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e.cleaned",
         "sha256": "e6e8a2193b1c03d3982125b0b058533a45f15a77d840e564d1a71c67cc08365e"
       }
     ],
-    "supplementary": []
+    "supplementary": [
+      {
+        "name": "temp_javascript.js",
+        "sha256": "2b4baabf25fccfafea989377ea7aa9ddf39baf9dc928e04ac61d1baea7091360"
+      }
+    ]
   },
   "results": {
     "heuristics": [
@@ -152,14 +214,23 @@
       },
       {
         "attack_ids": [],
-        "heur_id": 2,
-        "signatures": []
+        "heur_id": 3,
+        "signatures": [
+          "jquery_network_request"
+        ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "unescape"
+          "ajax_network_request"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "network_request"
         ]
       },
       {
@@ -167,6 +238,13 @@
         "heur_id": 3,
         "signatures": [
           "prepare_network_request"
+        ]
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "sleep"
         ]
       },
       {
@@ -180,31 +258,88 @@
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "cdn.jsdelivr.net"
+          "value": "folderdata021755.tk"
         },
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "folderdata021755.tk"
+          "value": "i.ibb.co"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "onlinebanking.mtb.com"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "usps.com"
+        }
+      ],
+      "network.dynamic.ip": [
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "127.0.0.1"
         }
       ],
       "network.dynamic.uri": [
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"
+          "value": "https://folderdata021755.tk/adminpanel/returnjson.php?session=127.0.0.1"
         },
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "https://folderdata021755.tk"
+          "value": "https://folderdata021755.tk/ads.php"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://folderdata021755.tk/d1.php"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://i.ibb.co/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "https://onlinebanking.mtb.com/login/mtbsignon"
         }
       ],
       "network.dynamic.uri_path": [
         {
           "heur_id": 2,
           "signatures": [],
-          "value": "/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css"
+          "value": "/adminpanel/returnjson.php?session=127.0.0.1"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/ads.php"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/d1.php"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/hgrxws2/tumblr-o8stot-saqr1ul8y65o1-1280.gif"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "/login/mtbsignon"
+        },
+        {
+          "heur_id": 2,
+          "signatures": [],
+          "value": "?load=1&session='+window['ip']"
         }
       ]
     },

--- a/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
+++ b/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
@@ -38,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in /tmp/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85: object ...",
+        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85: object Error...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
+++ b/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
@@ -16,28 +16,6 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates a Blob object\n\t\tnew Blob((function() {????var Module, moduleOverrides, key, arguments_, thisProgram, quit_, ENVIRONM...",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "creates_blob": 10
-          },
-          "signatures": {
-            "creates_blob": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: CreatesBlob",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n",
         "body_format": "TEXT",
         "classification": "TLP:W",
@@ -56,6 +34,28 @@
         },
         "tags": {},
         "title_text": "Signature: CreatesObjectURL",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob((function() {????var Module, moduleOverrides, key, arguments_, thisProgram, quit_, ENVIRONM...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "creates_blob": 10
+          },
+          "signatures": {
+            "creates_blob": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: CreatesBlob",
         "zeroize_on_tag_safe": false
       },
       {
@@ -156,14 +156,14 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "creates_blob"
+          "creates_object_url"
         ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "creates_object_url"
+          "creates_blob"
         ]
       },
       {

--- a/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
+++ b/tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json
@@ -16,7 +16,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates a Blob object\n\t\tnew Blob((function() {????var Module, moduleOverrides, key, arguments_, thisProgram, quit_, ENVIRONM...\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
+        "body": "JavaScript creates a Blob object\n\t\tnew Blob((function() {????var Module, moduleOverrides, key, arguments_, thisProgram, quit_, ENVIRONM...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -38,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
+        "body": "JavaScript creates an object URL with a blob\n\t\tURL.createObjectURL([object Blob])\n",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -60,29 +60,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript attempts to sleep\n\t\twindow[5].setTimeout(function() {\n\n\t\twindow[5].setTimeout(function(){_0x2063A(_0x2033D)},2000)\n",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "sleep": 10
-          },
-          "signatures": {
-            "sleep": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: Sleep",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript uses a suspicious process\n\t\tnew Worker(Blob[15])\n\n\t\t\tvar newW = new Worker(URL.createObjectURL(new Blob([\"(\" + function() {\\x0d",
+        "body": "JavaScript uses a suspicious process\n\t\tnew Worker(Blob[15])\n",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -100,6 +78,28 @@
         },
         "tags": {},
         "title_text": "Signature: SuspiciousProcess",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript attempts to sleep\n\t\twindow[5].setTimeout(function() {????informWorker(newW);???}, 2000)\n\n\t\twindow[5].setTimeout(function(){_0x2063A(_0x2033D)}, 2000)\n",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "sleep": 10
+          },
+          "signatures": {
+            "sleep": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: Sleep",
         "zeroize_on_tag_safe": false
       },
       {
@@ -170,14 +170,14 @@
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "sleep"
+          "suspicious_process"
         ]
       },
       {
         "attack_ids": [],
         "heur_id": 3,
         "signatures": [
-          "suspicious_process"
+          "sleep"
         ]
       }
     ],

--- a/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
+++ b/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
@@ -38,7 +38,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in /tmp/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f: object ...",
+        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in 87560992da11e28f83731fcd76d07cbf035d9151e9b717f54385653acbe59b02: object Error...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,

--- a/tests/test_jsjaws.py
+++ b/tests/test_jsjaws.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 import os
 import shutil
 
@@ -165,10 +166,37 @@ def remove_tmp_manifest():
 @pytest.fixture
 def dummy_request_class_instance():
     class DummyRequest():
+        SERVICE_CONFIG = {
+            "browser": "IE8",
+            "wscript_only": False,
+            "throw_http_exc": False,
+            "download_payload": False,
+            "extract_function_calls": False,
+            "extract_eval_calls": False,
+            "tool_timeout": 60,
+            "add_supplementary": False,
+            "static_signatures": True,
+            "no_shell_error": False,
+            "display_iocs": False,
+            "log_errors": False,
+            "static_analysis_only": False,
+            "enable_synchrony": False,
+        }
+
         def __init__(self):
             super(DummyRequest, self).__init__()
             self.temp_submission_data = {}
             self.result = None
+            self.file_contents = b""
+            self.file_type = "code/html"
+            self.sha256 = sha256(self.file_contents).hexdigest()
+            self.deep_scan = False
+
+        def add_supplementary(*args):
+            pass
+
+        def get_param(self, param):
+            return self.SERVICE_CONFIG[param]
 
     yield DummyRequest()
 
@@ -221,7 +249,7 @@ class TestJsJaws:
 
     @staticmethod
     def test_init(jsjaws_class_instance):
-        from assemblyline_v4_service.common.balbuzard.patterns import PatternMatch
+        from assemblyline.common.identify import Identify
 
         assert jsjaws_class_instance.artifact_list is None
         assert jsjaws_class_instance.malware_jail_payload_extraction_dir is None
@@ -237,13 +265,19 @@ class TestJsJaws:
         assert jsjaws_class_instance.extracted_wscript_path is None
         assert jsjaws_class_instance.malware_jail_output is None
         assert jsjaws_class_instance.malware_jail_output_path is None
-        assert jsjaws_class_instance.extracted_doc_writes is None
-        assert jsjaws_class_instance.extracted_doc_writes_path is None
         assert jsjaws_class_instance.boxjs_output_dir is None
         assert jsjaws_class_instance.boxjs_iocs is None
         assert jsjaws_class_instance.boxjs_resources is None
         assert jsjaws_class_instance.boxjs_analysis_log is None
         assert jsjaws_class_instance.boxjs_snippets is None
+        assert jsjaws_class_instance.filtered_lib is None
+        assert jsjaws_class_instance.filtered_lib_path is None
+        assert jsjaws_class_instance.cleaned_with_synchrony is None
+        assert jsjaws_class_instance.cleaned_with_synchrony_path is None
+        assert jsjaws_class_instance.stdout_limit is None
+        assert isinstance(jsjaws_class_instance.identify, Identify)
+        assert jsjaws_class_instance.safelist == {}
+        assert jsjaws_class_instance.doc_write_hashes is None
 
     @staticmethod
     def test_start(jsjaws_class_instance):
@@ -338,10 +372,6 @@ class TestJsJaws:
         assert jsjaws_class_instance.malware_jail_output_path == path.join(
             jsjaws_class_instance.working_directory, jsjaws_class_instance.malware_jail_output
         )
-        assert jsjaws_class_instance.extracted_doc_writes == "document_writes.html"
-        assert jsjaws_class_instance.extracted_doc_writes_path == path.join(
-            jsjaws_class_instance.malware_jail_payload_extraction_dir, jsjaws_class_instance.extracted_doc_writes
-        )
 
         assert path.exists(jsjaws_class_instance.malware_jail_payload_extraction_dir)
         assert path.exists(jsjaws_class_instance.malware_jail_sandbox_env_dir)
@@ -403,21 +433,31 @@ class TestJsJaws:
         }
 
     @staticmethod
-    def test_extract_doc_writes_one_liners(jsjaws_class_instance, dummy_request_class_instance):
+    def test_extract_doc_writes_one_liners(jsjaws_class_instance, dummy_request_class_instance, mocker):
         # Single line example : 697b0e897a7d57e600a1020886f837469ffb87acc65f04c2ae424af50a311c7e
         # Multiple calls to document.write() (with multiline) example :
         # 4b19570cb328f4e47a44e04a74c94993225203260607f615a875cd58500c9abb
-        from os import mkdir
-        from os.path import exists, join
 
-        jsjaws_class_instance.malware_jail_payload_extraction_dir = join(
-            jsjaws_class_instance.working_directory, "payload/"
+        jsjaws_class_instance.doc_write_hashes = set()
+        jsjaws_class_instance.stdout_limit = 10000
+        jsjaws_class_instance.boxjs_analysis_log = "blah"
+        root_dir = os.path.dirname(os.path.abspath(__file__))
+
+        jsjaws_class_instance.path_to_jailme_js = os.path.join(root_dir, "../", "tools/malwarejail/jailme.js")
+        jsjaws_class_instance.path_to_jsxray = os.path.join(root_dir, "../", "tools/js-x-ray-run.js")
+        jsjaws_class_instance.malware_jail_payload_extraction_dir = os.path.join(jsjaws_class_instance.working_directory, "payload/")
+        jsjaws_class_instance.malware_jail_sandbox_env_dump = "sandbox_dump.json"
+        jsjaws_class_instance.malware_jail_sandbox_env_dir = os.path.join(jsjaws_class_instance.working_directory, "sandbox_env")
+        jsjaws_class_instance.malware_jail_sandbox_env_dump_path = os.path.join(
+            jsjaws_class_instance.malware_jail_sandbox_env_dir, jsjaws_class_instance.malware_jail_sandbox_env_dump
         )
-        jsjaws_class_instance.extracted_doc_writes = "document_writes.html"
-        jsjaws_class_instance.extracted_doc_writes_path = join(
-            jsjaws_class_instance.malware_jail_payload_extraction_dir, jsjaws_class_instance.extracted_doc_writes
-        )
-        mkdir(jsjaws_class_instance.malware_jail_payload_extraction_dir)
+
+        mocker.patch.object(jsjaws_class_instance, "_extract_boxjs_iocs")
+        mocker.patch.object(jsjaws_class_instance, "_extract_wscript")
+        mocker.patch.object(jsjaws_class_instance, "_extract_payloads")
+        mocker.patch.object(jsjaws_class_instance, "_extract_urls")
+        mocker.patch.object(jsjaws_class_instance, "_extract_synchrony")
+
         output = [
             "[2022-10-18T20:12:49.924Z] document[15].write(content) 0 bytes",
             "[2022-10-18T20:12:50.924Z] => 'write me!'",
@@ -427,34 +467,19 @@ class TestJsJaws:
             "[2022-10-18T20:12:52.924Z] document[15].write(content) 0 bytes",
             "[2022-10-18T20:12:53.924Z] => 'password?!'",
         ]
-        jsjaws_class_instance.artifact_list = []
         jsjaws_class_instance._extract_doc_writes(output, dummy_request_class_instance)
-        assert exists(jsjaws_class_instance.extracted_doc_writes_path)
-        with open(jsjaws_class_instance.extracted_doc_writes_path, "r") as f:
-            assert f.read() == "write me!\nwrite me too!\npassword?!"
-        assert jsjaws_class_instance.artifact_list[0] == {
-            "name": jsjaws_class_instance.extracted_doc_writes,
-            "path": jsjaws_class_instance.extracted_doc_writes_path,
-            "description": "DOM Writes",
-            "to_be_extracted": True,
-        }
+        expected_doc_write = "write me!\nwrite me too!\npassword?!"
+        assert jsjaws_class_instance.doc_write_hashes == { sha256(expected_doc_write.encode()).hexdigest() }
         assert dummy_request_class_instance.temp_submission_data.get("passwords") == ['me', 'me!', 'password', 'password?!', 'too', 'too!', 'write']
 
     @staticmethod
-    def test_extract_doc_writes_multiliner(jsjaws_class_instance, dummy_request_class_instance):
+    def test_extract_doc_writes_multiliner(jsjaws_class_instance, dummy_request_class_instance, mocker):
         # Multiple calls to document.write() (with multiline) example :
         # 4b19570cb328f4e47a44e04a74c94993225203260607f615a875cd58500c9abb
-        from os import mkdir
-        from os.path import exists, join
 
-        jsjaws_class_instance.malware_jail_payload_extraction_dir = join(
-            jsjaws_class_instance.working_directory, "payload/"
-        )
-        jsjaws_class_instance.extracted_doc_writes = "document_writes.html"
-        jsjaws_class_instance.extracted_doc_writes_path = join(
-            jsjaws_class_instance.malware_jail_payload_extraction_dir, jsjaws_class_instance.extracted_doc_writes
-        )
-        mkdir(jsjaws_class_instance.malware_jail_payload_extraction_dir)
+        jsjaws_class_instance.doc_write_hashes = set()
+        jsjaws_class_instance.stdout_limit = 10000
+
         output = [
             "[2022-10-18T20:12:49.924Z] document[15].write(content) 0 bytes",
             "[2022-10-18T20:12:50.924Z] => '",
@@ -463,18 +488,49 @@ class TestJsJaws:
             "</html>'",
             "[2022-10-18T20:12:51.924Z] - Something else",
         ]
-        jsjaws_class_instance.artifact_list = []
         jsjaws_class_instance._extract_doc_writes(output, dummy_request_class_instance)
-        assert exists(jsjaws_class_instance.extracted_doc_writes_path)
-        with open(jsjaws_class_instance.extracted_doc_writes_path, "r") as f:
-            assert f.read() == "<html>\npassword: yabadabadoo\n</html>"
-        assert jsjaws_class_instance.artifact_list[0] == {
-            "name": jsjaws_class_instance.extracted_doc_writes,
-            "path": jsjaws_class_instance.extracted_doc_writes_path,
-            "description": "DOM Writes",
-            "to_be_extracted": True,
-        }
+        expected_doc_write = "<html>\npassword: yabadabadoo\n</html>"
+        assert jsjaws_class_instance.doc_write_hashes == { sha256(expected_doc_write.encode()).hexdigest() }
         assert dummy_request_class_instance.temp_submission_data.get("passwords") == [' yabadabadoo', 'password', 'password:', 'yabadabadoo']
+
+        dummy_request_class_instance.temp_submission_data = {}
+        jsjaws_class_instance.doc_write_hashes = set()
+
+        jsjaws_class_instance.boxjs_analysis_log = "blah"
+        root_dir = os.path.dirname(os.path.abspath(__file__))
+
+        jsjaws_class_instance.path_to_jailme_js = os.path.join(root_dir, "../", "tools/malwarejail/jailme.js")
+        jsjaws_class_instance.path_to_jsxray = os.path.join(root_dir, "../", "tools/js-x-ray-run.js")
+        jsjaws_class_instance.malware_jail_payload_extraction_dir = os.path.join(jsjaws_class_instance.working_directory, "payload/")
+        jsjaws_class_instance.malware_jail_sandbox_env_dump = "sandbox_dump.json"
+        jsjaws_class_instance.malware_jail_sandbox_env_dir = os.path.join(jsjaws_class_instance.working_directory, "sandbox_env")
+        jsjaws_class_instance.malware_jail_sandbox_env_dump_path = os.path.join(
+            jsjaws_class_instance.malware_jail_sandbox_env_dir, jsjaws_class_instance.malware_jail_sandbox_env_dump
+        )
+
+        mocker.patch.object(jsjaws_class_instance, "_extract_boxjs_iocs")
+        mocker.patch.object(jsjaws_class_instance, "_extract_wscript")
+        mocker.patch.object(jsjaws_class_instance, "_extract_payloads")
+        mocker.patch.object(jsjaws_class_instance, "_extract_urls")
+        mocker.patch.object(jsjaws_class_instance, "_extract_synchrony")
+
+        multiple_gauntlet_output = [
+            '[2022-12-21T21:06:23.655Z] document[6].write(content) 173 bytes',
+            '[2022-12-21T21:06:23.655Z] => \'<html><script>var b64_encoded = "PGh0bWw+CnBhc3N3b3JkOiB5YWJhZGFiYWRvbwo8L2h0bWw+";',
+            '    var b64_decoded = atob(b64_encoded);',
+            "    document.write(b64_decoded);</script></html>'",
+            '[2022-12-21T21:06:23.657Z] ==> Cleaning up sandbox.',
+        ]
+        jsjaws_class_instance._extract_doc_writes(multiple_gauntlet_output, dummy_request_class_instance)
+        expected_doc_write_1 = b'<html><script>var b64_encoded = "PGh0bWw+CnBhc3N3b3JkOiB5YWJhZGFiYWRvbwo8L2h0bWw+";\n    var b64_decoded = atob(b64_encoded);\n    document.write(b64_decoded);</script></html>'
+        expected_doc_write_2 = b'<html>\n\npassword: yabadabadoo\n\n</html>'
+        assert jsjaws_class_instance.doc_write_hashes == { sha256(expected_doc_write_1).hexdigest(), sha256(expected_doc_write_2).hexdigest() }
+        assert dummy_request_class_instance.temp_submission_data.get("passwords") == [
+            ' yabadabadoo',
+            'password',
+            'password:',
+            'yabadabadoo',
+        ]
 
     @staticmethod
     def test_extract_payloads(jsjaws_class_instance):

--- a/tests/test_jsjaws.py
+++ b/tests/test_jsjaws.py
@@ -181,6 +181,7 @@ def dummy_request_class_instance():
             "log_errors": False,
             "static_analysis_only": False,
             "enable_synchrony": False,
+            "override_eval": False,
         }
 
         def __init__(self):

--- a/tools/malwarejail/env/browser.js
+++ b/tools/malwarejail/env/browser.js
@@ -573,13 +573,11 @@ $.post = function (url, data, success, dataType) {
 
 // https://stackoverflow.com/questions/4083351/what-does-jquery-fn-mean
 $.fn = function () {
-    util_log(arguments);
+    util_log("$.fn(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",")) + ")")
     return this;
 }
 
 $.toString = () => { return "jQuery" }
-
-
 jQuery = $;
 
 Object.defineProperty(document, "location", {

--- a/tools/malwarejail/env/browser.js
+++ b/tools/malwarejail/env/browser.js
@@ -75,10 +75,16 @@ window = _proxy(new function () {
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Window/parent
     this.parent = this;
+    // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
     this.settimeout = function () {
-        util_log(this._name + ".setTimeout(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
+        const functionRef = arguments[0];
+        const delay = arguments[1];
+
+        util_log(this._name + ".setTimeout(" + _truncateOutput(functionRef) + ", " + delay + ")");
         _setTimeout_calls[_setTimeout_calls.length] = arguments[0].toString();
-        //util_log(typeof arguments[0]);
+
+        // We wait for no one!
+        arguments[1] = 0;
         return _setTimeout.apply(this, Array.prototype.slice.call(arguments, 0));
     }
     this.cleartimeout = function () {
@@ -88,10 +94,17 @@ window = _proxy(new function () {
     this.scrollby = function (x, y) {
         util_log(this._name + ".scrollBy(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
     }
+    // https://developer.mozilla.org/en-US/docs/Web/API/setInterval
     this.setinterval = function () {
-        util_log(this._name + ".setInterval(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
+        const func = arguments[0];
+        const delay = arguments[1];
+
+        util_log(this._name + ".setInterval(" + _truncateOutput(func) + ", " + delay + ")");
         _setInterval_calls[_setInterval_calls.length] = arguments[0].toString();
-        //util_log(typeof arguments[0]);
+
+        // We wait for no one!
+        arguments[1] = 0;
+
         return _setInterval.apply(this, Array.prototype.slice.call(arguments, 0));
     }
     this.clearinterval = function () {
@@ -179,6 +192,11 @@ window = _proxy(new function () {
     this.close = function() {
         util_log(this._name + ".close()")
     }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
+    this.load = function(fn) {
+        this.onload = fn;
+    }
+    this.ip = "127.0.0.1";
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
@@ -270,11 +288,15 @@ Document = _proxy(function () {
         util_log(this._name + ".getElementsByClassName(" + n + ") ... " + ret.length + " found");
         return ret;
     };
-        // https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById
-        this.getelementbyid = function (n) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById
+    this.getelementbyid = function (n) {
         util_log(this._name + ".getElementById(" + n + ")");
         if (n === undefined) {
             return this._elements[0];
+        } else if (n === this) {
+            return this;
+        } else if (n === window) {
+            return window;
         } else if (n.startsWith("#")) {
             n = n.slice(1,);
         }
@@ -327,6 +349,8 @@ Document = _proxy(function () {
             e = new Button(n);
         } else if (n.toLowerCase() === "input") {
             e = new Input(n);
+        } else if (n.toLowerCase() === "form") {
+            e = new Form(n);
         } else {
             e = new Element(n);
         }
@@ -415,11 +439,15 @@ Document = _proxy(function () {
     }
     // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
     this.addEventListener = function (type, listener) {
-        if (listener.constructor.name === "Function") {
-            var function_name = listener.prototype.name;
-            if (function_name === undefined) {
-                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+        if (["Function", "AsyncFunction"].includes(listener.constructor.name)) {
+            if (listener.prototype == undefined) {
                 function_name = "anonymous";
+            } else {
+                var function_name = listener.prototype.name;
+                if (function_name === undefined) {
+                    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+                    function_name = "anonymous";
+                }
             }
             util_log(this._name + ".addEventListener(" + type + ", " + function_name + ")")
             var e = null;
@@ -432,7 +460,7 @@ Document = _proxy(function () {
             util_log("Running function " + function_name + "(" + e + ")");
             listener(e);
         } else {
-            util_log(this._name + ".addEventListener(" + type + ", " + listener + ")")
+            util_log(this._name + ".addEventListener(" + type + ", " + _truncateOutput(listener) + ")")
         }
     }
     this.attachEvent = function (n) {
@@ -441,6 +469,11 @@ Document = _proxy(function () {
     this.URL = location;
     this.evaluate = function (n) {
         util_log(this._name + ".evaluate(" + n + ")");
+    }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event
+    this.keypress = function (listener) {
+        util_log(this._name + ".keypress()");
+        return this.addEventListener("keypress", listener);
     }
 
 })
@@ -479,6 +512,21 @@ $.ajax = function (url, settings) {
     util_log("$.ajax(" + JSON.stringify(url) + ")");
     ret = _proxy(new XMLHttpRequest(url));
     ret.open(url.type, url.url);
+    // See "jqXHR.done(function( data, textStatus, jqXHR ) {});" in https://api.jquery.com/Jquery.ajax/
+    ret.done = function(fn) {
+        util_log("$.ajax(" + JSON.stringify(url) + ").done(" + _truncateOutput(fn) + ")");
+        if (fn.constructor.name === "Function") {
+            var function_name = fn.prototype.name;
+            if (function_name === undefined) {
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#the_function_expression
+                function_name = "anonymous";
+            }
+            util_log("Running function " + function_name + "()");
+            // window == data
+            fn(window);
+        }
+    }
+    return ret;
 };
 
 // https://api.jquery.com/jquery.getJSON/
@@ -523,6 +571,17 @@ $.post = function (url, data, success, dataType) {
     ret.send(data);
 };
 
+// https://stackoverflow.com/questions/4083351/what-does-jquery-fn-mean
+$.fn = function () {
+    util_log(arguments);
+    return this;
+}
+
+$.toString = () => { return "jQuery" }
+
+
+jQuery = $;
+
 Object.defineProperty(document, "location", {
     get: function () {
         util_log("document.location.get()");
@@ -549,8 +608,14 @@ Image.prototype.constructor = Image;
 // https://developer.mozilla.org/en-US/docs/Web/API/Event
 Event = function() {
     this._id = _object_id++;
+    this._name = "Event[" + this._id + "]";
     this.origin = "null";
     this.data = "get";
     this.source = window;
-    util_log("new Event(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    util_log("new " + this._name + "(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault
+    this.preventDefault = function () {
+        util_log(this._name + ".preventDefault(" + _truncateOutput(Array.prototype.slice.call(arguments, 0).join(",") + ")"))
+    }
 };

--- a/tools/malwarejail/env/wscript.js
+++ b/tools/malwarejail/env/wscript.js
@@ -4,6 +4,8 @@
 
 const { resolveObjectURL } = require('node:buffer');
 const { win32 } = require('path');
+const CryptoJS = require("crypto-js");
+
 
 util_log("Preparing sandbox to emulate WScript environment.");
 _wscript_saved_files = {};
@@ -2257,6 +2259,12 @@ Element = _proxy(function (n) {
             util_log(this._name + ".append(" + param + ")");
         }
     }
+    this.hide = function () {
+        util_log(this._name + ".hide()");
+    }
+    this.show = function () {
+        util_log(this._name + ".show()");
+    }
     Object.defineProperty(this, "text", {
         // I have no idea why text is a callable method... but hey it works!
         get: function () {
@@ -2269,7 +2277,20 @@ Element = _proxy(function (n) {
             util_log(this._name + ".text = '" + v + "'");
             this._text = v;
         }
-    })
+    });
+    Object.defineProperty(this, "css", {
+        // I have no idea why text is a callable method... but hey it works!
+        get: function () {
+            util_log(this._name + ".css()");
+            return function() {
+                util_log(this._name + ".css(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
+            }
+        },
+        set: function (v) {
+            util_log(this._name + ".css = '" + v + "'");
+            util_log(arguments);
+        }
+    });
 });
 Element.prototype = Object.create(Node.prototype);
 Element.prototype.constructor = Element;
@@ -2343,15 +2364,60 @@ Input = _proxy(function (n) {
     this._name = "Input[" + this._id + "]";
     this.elementName = "input";
     this._attributes = {};
+    this.value = "JsJ@w$==C00l!";
     util_log("new " + this._name + "()");
     this.val = function() {
-        return "JsJ@w$==C00l!";
+        util_log(this._name + ".val() => " + this.value);
+        return this.value;
+    }
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+    this.focus = function() {
+        util_log(this._name + ".focus(" + Array.prototype.slice.call(arguments, 0).join(",") + ")");
+    }
+    this.addEventListener = function () {
+        const type = arguments[0];
+        const listener = arguments[1];
+        document.addEventListener(type, listener);
+    }
+    this.ForceLettersOnly = function () {
+        util_log(this._name + ".ForceLettersOnly()");
+    }
+    this.ForceNumericOnly = function () {
+        util_log(this._name + ".ForceNumericOnly()");
+    }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event
+    this.keypress = function (listener) {
+        util_log(this._name + ".keypress()");
+        return this.addEventListener("keypress", listener);
+    }
+    this.attr = function(key, value) {
+        util_log(this._name + ".attr(" + key + ", " + value + ")");
+        this._attributes[key] = value;
     }
 });
 Input.prototype = Object.create(Element.prototype);
 Input.prototype.constructor = Input;
 Input.toString = Input.toJSON = () => {
     return "Input"
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+Form = _proxy(function (n) {
+    Element.call(this, n);
+    this._id = _object_id++;
+    this._name = "Form[" + this._id + "]";
+    this.elementName = "form";
+    this._attributes = {};
+    util_log("new " + this._name + "()");
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset
+    this.reset = function () {
+        util_log(this._name + ".reset()");
+    }
+});
+Form.prototype = Object.create(Element.prototype);
+Form.prototype.constructor = Form;
+Form.toString = Form.toJSON = () => {
+    return "Form"
 }
 
 _WidgetManager = function () {

--- a/tools/malwarejail/jailme.js
+++ b/tools/malwarejail/jailme.js
@@ -230,6 +230,7 @@ var sandbox = {};
 sandbox.toLowerCase = function () {
     return "sandbox";
 }
+sandbox.value = "sandbox";
 sandbox.__dirname = path.resolve();
 
 // too ambitious
@@ -388,7 +389,8 @@ function run_in_ctx(files, log_catch = false) {
             }
             vm.runInContext(fc, ctx, {
                 filename: files[i],
-                timeout: config.timeout
+                timeout: config.timeout,
+                breakOnSigint: true,
             });
             _dont_log = false;
         }

--- a/tools/malwarejail/jailme.js
+++ b/tools/malwarejail/jailme.js
@@ -400,9 +400,20 @@ function run_in_ctx(files, log_catch = false) {
             console.log("Execution finished: " + err._source);
             return true;
         }
-        console.log("Exception occurred in " + files[i] + ": " + typeof err + " " + util.inspect(err));
-        //if (typeof err.stack !== 'undefined')
-        //    console.log("Stack: " + err.stack);
+        // We want to display the hash of the file in the exception, for consistency
+        const hash = createHash("sha256");
+        const input = fs.createReadStream(files[i]);
+        input.on('readable', () => {
+            const data = input.read();
+            if (data)
+                hash.update(data);
+            else {
+                const file_hash = hash.digest("hex");
+                console.log("Exception occurred in " + file_hash + ": " + typeof err + " " + util.inspect(err));
+                console.log("The hash " + file_hash + " corresponds to " + files[i]);
+            }
+        })
+
         return false;
     } finally {
         _dont_log = false;

--- a/tools/package.json
+++ b/tools/package.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "@nodesecure/js-x-ray": "^5.1.0",
         "box-js": "^1.9.15",
+        "crypto-js": "^4.1.1",
         "deobfuscator": "^2.4.1",
         "entities": "^1.1.1",
         "iconv-lite": "^0.4.13",


### PR DESCRIPTION
Closes https://cccs.atlassian.net/browse/AL-2066

Dependent on https://github.com/CybercentreCanada/assemblyline-v4-service/pull/490

Initially this ticket was aimed at providing the `CryptoJS` library for use in MalwareJail. You can see this library being imported in `tools/package.json` and `tools/malwarejail/env/wscript.js`.

Then it raised the question of elements written to the DOM requiring previously declared variables. This let to the concept of the "gauntlet". Using this concept, is there are any new elements written to the DOM, the new elements will be appended to the current DOM and re-run through JsJaws' toolset. The artifacts and signatures raised are only those from the final run, since this is based on the most complete DOM.

- `al_config/system_safelist.yaml`:
    - Add another domain/URI to safelist
- `jsjaws.py`:
    - Added the concept of the "gauntlet"
    - Removed the extraction of new elements that were written to the DOM
    - Fixed the safelist declaration
    - Added a set that will contain the hashes of the new elements written to the DOM, which will be used for safe recursion
    - Box.js has difficulty running multiple times on the same execution, since it doesn't perform it's own cleanup.
    - Check if any threads were unable to be joined, and log to aid with debugging
    - Enforce the STDOUT limit on the MalwareJail output when calling `_extract_malware_jail_iocs` and `_extract_doc_writes`
    - Using the artifact list to add extracted and supplementary files, since there is further validation that takes place
    - Some bug fixes regarding dynamically creating elements in JsJaws
    - All threads should be run with `daemon=True`
    - Exit the `Popen` if the output exceeds the STDOUT limit, since this implies an infinite loop
- `signatures/decode.py`:
    - Added a signature that looks for the `CryptoJS` library usage
- `tests/results/55b67b30917c6786f9d53a39af6166ca638c797c408c8743e705680ecb807f09/result.json`:
    - Added this sample since it is open source and uses a lot of improvements from previous PRs
- `tests/results/b7bdf656cc3363e92542834aad8c9c6c3a6e1888fc9affa538b8896bd8650025/result.json`:
    - This hash change is because of a bug fix where the dividing comment was inserted despite there being no content to divide
- `tests/results/bf57c2fa6f6c71786b18a43c2e0979c305d21a7dba7b206d6eca29dbe3c49799/result.json`:
    - We are no longer extracted DOM writes now that we are moving to the "gauntlet" concept
- `tests/results/c9028d1ae8714281c981859069d0bca99c26e3969d6e95323e4c546faab2457e/result.json`:
    - This file was most affected by the "gauntlet" concept from our sample tests
    - We were able to get deeper into the sample with this concept and were able to get several beacons
- `tests/results/f8ef6424a3bd53291b29c7688febf6f615f3e7816046f1481310f287d023d9f7/result.json`:
    - Some ordering of signatures changed, nothing crazy
- `tests/test_jsjaws.py`:
    - Added what was required to facilitate the "gauntlet", as well as improved the tests that hit on `_extract_doc_writes`
- `tools/malwarejail/env/browser.js`:
    - in the `settimeout` and `setinterval`, we will not wait for the delay.
    - added a Form element
    - added a `done` method for `$.ajax`
    - misc. improvements
- `tools/malwarejail/env/wscript.js`:
    - added generic user interaction methods
    - misc. improvements