### PR TITLE
We should be running the embedded malicious code, not extracting it f…

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -174,6 +174,12 @@ heuristics:
     filetype: '*'
     description: Sample consists of a long single line of code
 
+  - heur_id: 11
+    name: Time Waster
+    score: 1
+    filetype: '*'
+    description: Sample uses common time-wasting techniques
+
 docker_config:
   allow_internet_access: true
   image: ${REGISTRY}cccs/assemblyline-service-jsjaws:$SERVICE_TAG

--- a/tests/results/40c70ac063d55e6fa83fd4fcb80f079b6a30e1cc1d91e030c4c8347ba3d978de/result.json
+++ b/tests/results/40c70ac063d55e6fa83fd4fcb80f079b6a30e1cc1d91e030c4c8347ba3d978de/result.json
@@ -1,8 +1,44 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1010,
+    "score": 1021,
     "sections": [
+      {
+        "auto_collapse": false,
+        "body": "Common library used: clean_libs/maplace0.2.7.js",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 4,
+          "score": 1000,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "Embedded code was found in common library",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 11,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "This sample uses common time-wasting techniques",
+        "zeroize_on_tag_safe": false
+      },
       {
         "auto_collapse": false,
         "body": null,
@@ -12,6 +48,28 @@
         "heuristic": null,
         "tags": {},
         "title_text": "Signatures",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in 8048d4ebad7b0b965181e93f74dba7229e4130b90b860b50102bd0b77019f033: object Error...",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 3,
+          "score": 10,
+          "score_map": {
+            "antisandbox_timeout": 10
+          },
+          "signatures": {
+            "antisandbox_timeout": 1
+          }
+        },
+        "tags": {},
+        "title_text": "Signature: AntiSandboxTimeout",
         "zeroize_on_tag_safe": false
       },
       {
@@ -35,38 +93,22 @@
         "tags": {},
         "title_text": "Signature: SuspiciousFunctionCall",
         "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "View extracted file filtered_lib.js for details.",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 4,
-          "score": 1000,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "Embedded code was found in common library",
-        "zeroize_on_tag_safe": false
       }
     ]
   },
   "files": {
-    "extracted": [
-      {
-        "name": "filtered_lib.js",
-        "sha256": "8048d4ebad7b0b965181e93f74dba7229e4130b90b860b50102bd0b77019f033"
-      }
-    ],
+    "extracted": [],
     "supplementary": []
   },
   "results": {
     "heuristics": [
+      {
+        "attack_ids": [],
+        "heur_id": 3,
+        "signatures": [
+          "antisandbox_timeout"
+        ]
+      },
       {
         "attack_ids": [],
         "heur_id": 3,
@@ -77,6 +119,11 @@
       {
         "attack_ids": [],
         "heur_id": 4,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 11,
         "signatures": []
       }
     ],

--- a/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
+++ b/tests/results/e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85/result.json
@@ -1,8 +1,44 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1031,
+    "score": 1021,
     "sections": [
+      {
+        "auto_collapse": false,
+        "body": "Common library used: clean_libs/underscore1.13.6.js",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 4,
+          "score": 1000,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "Embedded code was found in common library",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 11,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "This sample uses common time-wasting techniques",
+        "zeroize_on_tag_safe": false
+      },
       {
         "auto_collapse": false,
         "body": null,
@@ -16,29 +52,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript uses unescape() to decode an encoded string\n\t\tvar unescapeMap = invert(escapeMap)\n\t\tvar _unescape = createEscaper(unescapeMap)\n\t\t  unescape: _unescape,",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "unescape": 10
-          },
-          "signatures": {
-            "unescape": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: Unescape",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in e826df2ff2104f8fe4e968ce85ea3530f03236d28e3af0efe6f3dd4e28b4fb85: object Error...",
+        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in b810dbb154f0e3d11700a9427feb1f86f5672353de86f7e9054f7ead1130ef60: object Error...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -79,68 +93,15 @@
         "tags": {},
         "title_text": "Signature: SuspiciousFunctionCall",
         "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "View extracted file filtered_lib.js for details.",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 4,
-          "score": 1000,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "Embedded code was found in common library",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "\t\tAn unsafe statement was found: Function",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 2,
-          "score": 1,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "JS-X-Ray IOCs Detected",
-        "zeroize_on_tag_safe": false
       }
     ]
   },
   "files": {
-    "extracted": [
-      {
-        "name": "filtered_lib.js",
-        "sha256": "b810dbb154f0e3d11700a9427feb1f86f5672353de86f7e9054f7ead1130ef60"
-      }
-    ],
+    "extracted": [],
     "supplementary": []
   },
   "results": {
     "heuristics": [
-      {
-        "attack_ids": [],
-        "heur_id": 2,
-        "signatures": []
-      },
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "unescape"
-        ]
-      },
       {
         "attack_ids": [],
         "heur_id": 3,
@@ -158,6 +119,11 @@
       {
         "attack_ids": [],
         "heur_id": 4,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 11,
         "signatures": []
       }
     ],

--- a/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
+++ b/tests/results/fe988f34d74e1f975a872876f002b85ab55181e58d15de7a5d93e01adcf4b62f/result.json
@@ -1,8 +1,44 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1030,
+    "score": 1021,
     "sections": [
+      {
+        "auto_collapse": false,
+        "body": "Common library used: clean_libs/combo.js",
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 4,
+          "score": 1000,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "Embedded code was found in common library",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_format": "TEXT",
+        "classification": "TLP:W",
+        "depth": 0,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 11,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "tags": {},
+        "title_text": "This sample uses common time-wasting techniques",
+        "zeroize_on_tag_safe": false
+      },
       {
         "auto_collapse": false,
         "body": null,
@@ -16,29 +52,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "JavaScript removes objects from the DOM\n\t\t    elem.parentNode.removeChild(elem)\n\t\t        elem.parentNode.removeChild(elem)",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 3,
-          "score": 10,
-          "score_map": {
-            "hide_object": 10
-          },
-          "signatures": {
-            "hide_object": 1
-          }
-        },
-        "tags": {},
-        "title_text": "Signature: HideObjects",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in 87560992da11e28f83731fcd76d07cbf035d9151e9b717f54385653acbe59b02: object Error...",
+        "body": "JavaScript file managed to delay execution until the sandbox timed out\n\t\tException occurred in 1c341bdedcfd3c29f2158ce5e86fda994ba1e51d0e285614b9a3ec97c7cee021: object Error...",
         "body_format": "TEXT",
         "classification": "TLP:W",
         "depth": 1,
@@ -79,45 +93,15 @@
         "tags": {},
         "title_text": "Signature: SuspiciousFunctionCall",
         "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "View extracted file filtered_lib.js for details.",
-        "body_format": "TEXT",
-        "classification": "TLP:W",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 4,
-          "score": 1000,
-          "score_map": {},
-          "signatures": {}
-        },
-        "tags": {},
-        "title_text": "Embedded code was found in common library",
-        "zeroize_on_tag_safe": false
       }
     ]
   },
   "files": {
-    "extracted": [
-      {
-        "name": "filtered_lib.js",
-        "sha256": "216a067b872857cedb992570130eee9241e4156cc91a2ec3e739784f77c6ce3e"
-      }
-    ],
+    "extracted": [],
     "supplementary": []
   },
   "results": {
     "heuristics": [
-      {
-        "attack_ids": [],
-        "heur_id": 3,
-        "signatures": [
-          "hide_object"
-        ]
-      },
       {
         "attack_ids": [],
         "heur_id": 3,
@@ -135,6 +119,11 @@
       {
         "attack_ids": [],
         "heur_id": 4,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 11,
         "signatures": []
       }
     ],


### PR DESCRIPTION
…or subsequent runs
Partially addresses https://cccs.atlassian.net/browse/AL-2218

This PR changes the flow of embedded code in common libraries.

The previous method was to try running the original sample, then extracting the embedded code for a subsequent run.

The new method is to grab the embedded code from the original sample and run that.

This way, we are able to determine if the reason the code crashes / stalls is due to the embedded code rather than the library + embedded code.

Also added a method uses regular expressions that looks for common time-wasting techniques, and decreases the tool timeout to 5 seconds so that we aren't wasting a lot of time executing these files.