### PR TITLE
Cast tool_timeout param to int

### DIFF
--- a/jsjaws.py
+++ b/jsjaws.py
@@ -564,7 +564,7 @@ class JsJaws(ServiceBase):
         download_payload = request.get_param("download_payload")
         allow_download_from_internet = self.config.get("allow_download_from_internet", False)
         if not is_time_waster:
-            tool_timeout = request.get_param("tool_timeout")
+            tool_timeout = int(request.get_param("tool_timeout"))
         else:
             # Arbitrary small tool timeout
             tool_timeout = 5


### PR DESCRIPTION
Partially addressing https://cccs.atlassian.net/browse/AL-2330

In the AL UI, adjusting this value changes the value type to a string for some reason, bugfix ticket is being raised...
![image](https://user-images.githubusercontent.com/59843993/224796439-f407d7b2-5e53-44b4-9382-0f557327d6da.png)
