### PR TITLE
Adding a limit to the VBSCRIPT_ENV_SETTING_REGEX to avoid backtracking

### DIFF
--- a/jsjaws.py
+++ b/jsjaws.py
@@ -219,7 +219,7 @@ ELEMENT_INDEX_REGEX = re.compile(b"const element(\d+)_jsjaws = ")
 # Example:
 # wscript_shell_object_env("test") = "Hello World!";
 VBSCRIPT_ENV_SETTING_REGEX = \
-    b"\((?P<property_name>[\w\d\s()\'\"+\\\\]{2,})\)\s*=\s*(?P<property_value>[^>=;\.]+?[^>=;]+);"
+    b"\((?P<property_name>[\w\s()\'\"+\\\\]{2,1000})\)\s*=\s*(?P<property_value>[^>=;\.]+?[^>=;]+);"
 
 # Example:
 # Exception occurred in aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: object blahblah:123


### PR DESCRIPTION
Closes https://cccs.atlassian.net/browse/AL-2387