### PR TITLE
Remove access to require and fs in malwarejail

### DIFF
--- a/tools/malwarejail/env/util/console.js
+++ b/tools/malwarejail/env/util/console.js
@@ -26,7 +26,7 @@ console = _proxy({
         util_log(this._name + ".dirxml(" + a + ")");
     },
     error: function(a) {
-        util_log(this._name + ".(" + a + ")");
+        util_log(this._name + ".error(" + a + ")");
     },
     group: function(a) {
         util_log(this._name + ".group(" + a + ")");

--- a/tools/malwarejail/jailme.js
+++ b/tools/malwarejail/jailme.js
@@ -435,6 +435,9 @@ if (!run_in_ctx(config.sandbox_sequence, false)) process.exit();
 //    process.exit(2);
 //});
 
+// Remove unneeded context
+ctx.require = function (required_lib) { console.log("require(" + required_lib + ")");}
+ctx.fs = {}
 // Run the malware
 console.log("==> Executing malware file(s). =========================================");
 process.exitCode = run_in_ctx(config.malware_files, config.logerrors) ? 0 : 1;


### PR DESCRIPTION
require and fs are both node specific and so should not be required for browser emulation.  Monkeypatching so they can't be used when the malware sample is running.

This does not make it secure to run malwarejail as it uses vm internally for sandboxing, which is not secure by design. Malwarejail (and therefore JsJaws) should only be run in a controlled environment.